### PR TITLE
Fixing tables in `TreeView` documentation

### DIFF
--- a/docs/documentation/docs/controls/TreeView.md
+++ b/docs/documentation/docs/controls/TreeView.md
@@ -100,6 +100,7 @@ The `TreeView` control can be configured with the following properties:
 Enum `TreeViewSelectionMode`
 
 Specifies the selection mode of tree item.
+
 | Value    |
 |----------|
 | Single   |
@@ -126,7 +127,8 @@ Each tree item in the `treeitems` property is defined as `ITreeItem` as follows:
 Interface `ITreeItemAction`
 
 Specifies the list of actions for the tree item.
-| Property             | Type                                 | Required | Description                                                                                                                |
+
+| Property             | Type                                 | Required | Description |
 |----------------------|--------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------|
 | id                   | string                               | yes      | Unique id of the action.                                                                                                   |
 | title                | string                               | yes      | Title of the action.                                                                                                       |
@@ -138,6 +140,7 @@ Specifies the list of actions for the tree item.
 Enum `TreeItemActionsDisplayMode`
 
 Specifies the display mode of the tree item action.
+
 | Value          |
 |----------------|
 | Buttons        |


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Some tables in `TreeView` documentation are displayed as plain text. This PR fixes the docs.