### PR TITLE
Fixed default behavior of defaultExpanded property

### DIFF
--- a/src/controls/treeView/TreeItem.tsx
+++ b/src/controls/treeView/TreeItem.tsx
@@ -171,7 +171,7 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
             this.props.showCheckboxes && item.selectable == false && !item.children &&
             <span className={styles.blankspace}>&nbsp;</span>
           }
-          
+
           {
             // Rendering when item has iconProps
             item.iconProps &&
@@ -214,7 +214,7 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
         return (
           <TreeItem
             treeItem={item}
-            defaultExpanded={treeItem.key === item.key ? this.state.expanded : false}
+            defaultExpanded={this.state.expanded}
             leftOffset={paddingLeft}
             selectionMode={selectionMode}
             activeItems={activeItems}

--- a/src/controls/treeView/TreeView.tsx
+++ b/src/controls/treeView/TreeView.tsx
@@ -173,6 +173,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
   public render(): JSX.Element {
     const {
       items,
+      defaultExpanded,
       selectionMode,
       onRenderItem,
       showCheckboxes,
@@ -187,7 +188,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
               treeItem={treeNodeItem}
               leftOffset={20}
               isFirstRender={true}
-              defaultExpanded={true}
+              defaultExpanded={defaultExpanded}
               selectionMode={selectionMode}
               activeItems={this.state.activeItems}
               parentCallbackExpandCollapse={this.handleTreeExpandCollapse}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| Related issues?  | fixes https://github.com/pnp/sp-dev-fx-controls-react/issues/560

#### What's in this Pull Request?
Fixed default behavior of defaultExpanded property. Setting defaultExpanded property to true opens all the nodes of the TreeView.