### PR TITLE
Correct the AnchorID getting all TermSet search options

### DIFF
--- a/src/controls/taxonomyPicker/TermPicker.tsx
+++ b/src/controls/taxonomyPicker/TermPicker.tsx
@@ -112,7 +112,7 @@ export default class TermPicker extends React.Component<ITermPickerProps, ITermP
   private async onFilterChanged(filterText: string, tagList: IPickerTerm[]): Promise<IPickerTerm[]> {
     if (filterText !== "") {
       let termsService = new SPTermStorePickerService(this.props.termPickerHostProps, this.props.context);
-      let terms: IPickerTerm[] = await termsService.searchTermsByName(filterText);
+      let terms: IPickerTerm[] = await termsService.searchTermsByTermId(filterText, this.props.termPickerHostProps.anchorId);
       // Check if the termset can be selected
       if (this.props.isTermSetSelectable) {
         // Retrieve the current termset


### PR DESCRIPTION
| Q          | A
| --------------- | ---
| Bug fix?        | [ X]

#### What's in this Pull Request?

When using the Option AnchorID on the TaxonomyPicker, it only shows on the panel the correct option to pick from, but when using the type, it'll display all the other terms of the terms. 

![AnchorID](https://user-images.githubusercontent.com/40799678/83022328-44652400-a023-11ea-983c-f51092874d41.gif)


#150 
#341 