### PR TITLE
Fix #576 DateTimePicker noon/midnight wrong time when 12hr format

### DIFF
--- a/src/controls/dateTimePicker/DateTimePicker.tsx
+++ b/src/controls/dateTimePicker/DateTimePicker.tsx
@@ -125,9 +125,17 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
       }
 
       if (this.props.timeConvention !== TimeConvention.Hours24) {
-        if (hoursSplit[1] && hoursSplit[1].toLowerCase().indexOf("am") !== -1) {
+        if (hoursSplit[1] && hoursSplit[1].toLowerCase().indexOf("pm") !== -1) {
           hours += 12;
           if (hours === 24) {
+            //this is noon - set to 12 not 0
+            //hours = 0;
+            hours = 12;
+          }
+        }
+        else {
+          //am - if hours == 12, set hours to 0 here
+          if (hours == 12){
             hours = 0;
           }
         }

--- a/src/controls/dateTimePicker/DateTimePicker.tsx
+++ b/src/controls/dateTimePicker/DateTimePicker.tsx
@@ -125,7 +125,7 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
       }
 
       if (this.props.timeConvention !== TimeConvention.Hours24) {
-        if (hoursSplit[1] && hoursSplit[1].toLowerCase().indexOf("pm") !== -1) {
+        if (hoursSplit[1] && hoursSplit[1].toLowerCase().indexOf("am") !== -1) {
           hours += 12;
           if (hours === 24) {
             hours = 0;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Added logic to set hours correctly when 12PM and 12AM are chosen, when 12 hour format is used. If there is a better way to accomplish, I can assist there as well, this is how I was able to get it functioning correctly.
