### PR TITLE
updated imports for lodash to work correctly in SP 2016

### DIFF
--- a/src/common/utilities/GeneralHelper.ts
+++ b/src/common/utilities/GeneralHelper.ts
@@ -2,7 +2,7 @@ import { IContext } from '../Interfaces';
 import { SPHelper } from './SPHelper';
 import '../extensions/String.extensions';
 
-import * as _ from '@microsoft/sp-lodash-subset';
+//import * as _ from '@microsoft/sp-lodash-subset';
 
 import * as strings from 'ControlStrings';
 

--- a/src/controls/fields/fieldUserRenderer/FieldUserRenderer.tsx
+++ b/src/controls/fields/fieldUserRenderer/FieldUserRenderer.tsx
@@ -1,7 +1,7 @@
 import { override } from '@microsoft/decorators';
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-import * as _ from '@microsoft/sp-lodash-subset';
+import { clone } from '@microsoft/sp-lodash-subset';
 import { IExpandingCardProps } from 'office-ui-fabric-react/lib/HoverCard';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
 import { Persona, PersonaSize } from 'office-ui-fabric-react/lib/Persona';
@@ -308,7 +308,7 @@ export class FieldUserRenderer extends React.Component<IFieldUserRendererProps, 
 
     this._loadedUserProfiles[user.id] = userProfileProps;
     this.setState((prevState: IFieldUserRendererState, componentProps: IFieldUserRendererProps) => {
-      const newUsers = _.clone<IFieldUser[]>(prevState.users);
+      const newUsers = clone<IFieldUser[]>(prevState.users);
       newUsers[index] = this._getUserFromPrincipalAndProps(this.props.users[index], userProfileProps);
 
       return { users: newUsers };

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -10,7 +10,8 @@ import { Label } from 'office-ui-fabric-react/lib/components/Label';
 import { IBasePickerSuggestionsProps } from "office-ui-fabric-react/lib/components/pickers/BasePicker.types";
 import { IPersonaProps } from "office-ui-fabric-react/lib/components/Persona/Persona.types";
 import { Icon } from "office-ui-fabric-react/lib/components/Icon";
-import { isEqual, uniqBy } from "@microsoft/sp-lodash-subset";
+import isEqual = require('lodash/isEqual');
+import uniqBy = require('lodash/uniqBy');
 
 /**
  * PeoplePicker component

--- a/src/controls/taxonomyPicker/TaxonomyPicker.tsx
+++ b/src/controls/taxonomyPicker/TaxonomyPicker.tsx
@@ -10,7 +10,8 @@ import SPTermStorePickerService from './../../services/SPTermStorePickerService'
 import { ITermSet, ITerm } from './../../services/ISPTermStorePickerService';
 import * as strings from 'ControlStrings';
 import styles from './TaxonomyPicker.module.scss';
-import { sortBy, uniqBy, cloneDeep, isEqual } from '@microsoft/sp-lodash-subset';
+import { sortBy, cloneDeep, isEqual } from '@microsoft/sp-lodash-subset';
+import uniqBy = require('lodash/uniqBy');
 import TermParent from './TermParent';
 import FieldErrorMessage from './ErrorMessage';
 

--- a/src/controls/treeView/TreeView.tsx
+++ b/src/controls/treeView/TreeView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styles from './TreeView.module.scss';
-import { uniqBy } from '@microsoft/sp-lodash-subset';
+import uniqBy  = require('lodash/uniqBy');
 import { ITreeViewProps, TreeViewSelectionMode } from './ITreeViewProps';
 import { ITreeViewState } from './ITreeViewState';
 import { ITreeItem } from './ITreeItem';


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | #183 

#### What's in this Pull Request?

imports of lodash elements are revised to work correctly in SP2016 (SPFx v1.1) - `uniqBy` is imported from `lodash/uniqBy` instead of `@microsoft/sp-lodash-subset`.
It should not impact the bundle size as we import other things from `lodash` anyway