### PR TITLE
Required prop for Taxonomy Picker

### DIFF
--- a/docs/documentation/docs/controls/TaxonomyPicker.md
+++ b/docs/documentation/docs/controls/TaxonomyPicker.md
@@ -166,6 +166,9 @@ The TaxonomyPicker control can be configured with the following properties:
 | hideTagsNotAvailableForTagging | boolean | no | Specifies if the tags marked with 'Available for tagging' = false should be hidden |
 | hideDeprecatedTags | boolean | no | Specifies if deprecated tags  should be hidden |
 | placeholder | string | no | Short text hint to display in empty picker |
+| errorMessage | string | no | Static error message displayed below the text field. Use `onGetErrorMessage` to dynamically change the error message displayed (if any) based on the current value. `errorMessage` and `onGetErrorMessage` are mutually exclusive (`errorMessage` takes precedence). |
+| onGetErrorMessage | (value: IPickerTerms) => string \| Promise&lt;string&gt; | no | The method is used to get the validation error message and determine whether the input value is valid or not. Mutually exclusive with the static string `errorMessage` (it will take precedence over this).<br />When it returns string:<ul><li>If valid, it returns empty string.</li><li>If invalid, it returns the error message string and the text field will</li><li>show a red border and show an error message below the text field.</li></ul><br />When it returns Promise&lt;string&gt;:<ul><li>The resolved value is display as error message.</li><li>The rejected, the value is thrown away.</li></ul> |
+| required | boolean | no | Specifies if to display an asterisk near the label. Note that error message should be specified in `onGetErrorMessage` or `errorMessage` |
 
 Interface `IPickerTerm`
 

--- a/src/controls/taxonomyPicker/ErrorMessage.tsx
+++ b/src/controls/taxonomyPicker/ErrorMessage.tsx
@@ -11,7 +11,7 @@ export interface IFieldErrorMessageProps {
  */
 export default class FieldErrorMessage extends React.Component<IFieldErrorMessageProps> {
   public render(): JSX.Element {
-    if (this.props.errorMessage !== 'undefined' && this.props.errorMessage !== null && this.props.errorMessage !== '') {
+    if (this.props.errorMessage !== undefined && this.props.errorMessage !== null && this.props.errorMessage !== '') {
       return (
         <div aria-live="assertive">
           <p className={`ms-TextField-errorMessage ${styles.errorMessage}`}>

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -81,6 +81,7 @@ export interface ITaxonomyPickerProps  {
 
   /**
    * The method is used to get the validation error message and determine whether the input value is valid or not.
+   * Mutually exclusive with the static string errorMessage (it will take precedence over this).
    *
    *   When it returns string:
    *   - If valid, it returns empty string.
@@ -95,9 +96,20 @@ export interface ITaxonomyPickerProps  {
   onGetErrorMessage?: (value: IPickerTerms) => string | Promise<string>;
 
   /**
+   * Static error message displayed below the text field. Use onGetErrorMessage to dynamically change the error message displayed (if any) based on the current value. errorMessage and onGetErrorMessage are mutually exclusive (errorMessage takes precedence).
+   */
+  errorMessage?: string;
+
+  /**
    * onChange Event
    */
   onChange?: (newValue?: IPickerTerms) => void;
+
+  /**
+   * Specifies if to display an asterisk near the label.
+   * Note that error message should be specified in onGetErrorMessage
+   */
+  required?: boolean;
 }
 
 /**

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -643,13 +643,16 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
           <TaxonomyPicker
             allowMultipleSelections={true}
-            termsetNameOrID="e813224c-bb1b-4086-b828-3d71434ddcd7" // id to termset that has a default sort
+            termsetNameOrID="8ea5ac06-fd7c-4269-8d0d-02f541df8eb9" // id to termset that has a default sort
             panelTitle="Select Default Sorted Term"
             label="Service Picker"
             context={this.props.context}
             onChange={this.onServicePickerChange}
             isTermSetSelectable={false}
             placeholder="Select service"
+            required={true}
+            errorMessage='this field is required'
+            onGetErrorMessage={(value) => { return 'comment errorMessage to see this one'; }}
           />
 
           <TaxonomyPicker
@@ -1250,7 +1253,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           //limiterIcon={"NumberedListText"}
           />
         </div>
-        
+
         <div>
           <FieldCollectionData
             key={"FieldCollectionData"}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | implements #216 

#### What's in this Pull Request?

The PR adds 3 new properties to `TaxonomyPicker` control:

| Property | Type | Required | Description |
| ---- | ---- | ---- | ---- |
| errorMessage | string | no | Static error message displayed below the text field. Use `onGetErrorMessage` to dynamically change the error message displayed (if any) based on the current value. `errorMessage` and `onGetErrorMessage` are mutually exclusive (`errorMessage` takes precedence). |
| onGetErrorMessage | (value: IPickerTerms) => string \| Promise&lt;string&gt; | no | The method is used to get the validation error message and determine whether the input value is valid or not. Mutually exclusive with the static string `errorMessage` (it will take precedence over this).<br />When it returns string:<ul><li>If valid, it returns empty string.</li><li>If invalid, it returns the error message string and the text field will</li><li>show a red border and show an error message below the text field.</li></ul><br />When it returns Promise&lt;string&gt;:<ul><li>The resolved value is display as error message.</li><li>The rejected, the value is thrown away.</li></ul> |
| required | boolean | no | Specifies if to display an asterisk near the label. Note that error message should be specified in `onGetErrorMessage` or `errorMessage` |