### PR TITLE
612 taxonomypicker error message always displayed

### DIFF
--- a/docs/documentation/docs/controls/TaxonomyPicker.md
+++ b/docs/documentation/docs/controls/TaxonomyPicker.md
@@ -164,6 +164,7 @@ The TaxonomyPicker control can be configured with the following properties:
 | anchorId | string | no | Set the anchorid to a child term in the TermSet to be able to select terms from that level and below. |
 | termActions | ITermActions | no | Allows to execute custom action on the term like e.g. get other term labelsITermActions. |
 | hideTagsNotAvailableForTagging | boolean | no | Specifies if the tags marked with 'Available for tagging' = false should be hidden |
+| validateOnLoad | boolean | no | Specifies if the initial values will be validated, when the component is loaded. Default value is false |
 | hideDeprecatedTags | boolean | no | Specifies if deprecated tags  should be hidden |
 | placeholder | string | no | Short text hint to display in empty picker |
 

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -114,6 +114,7 @@ export interface ITaxonomyPickerState {
   openPanel?: boolean;
   loaded?: boolean;
   activeNodes?: IPickerTerms;
+  invalidTerms?: IPickerTerms;
 }
 
 export interface ITermChanges {

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -9,9 +9,9 @@ import { ExtensionContext } from '@microsoft/sp-extension-base';
  * PropertyFieldTermPickerHost properties interface
 //  */
 export interface ITaxonomyPickerProps  {
-   /**
-   * Property field label displayed on top
-   */
+  /**
+  * Property field label displayed on top
+  */
   label: string;
   /**
    * TermSet Picker Panel title
@@ -78,6 +78,11 @@ export interface ITaxonomyPickerProps  {
    * Placeholder to be displayed in an empty term picker
    */
   placeholder?: string;
+
+  /**
+   * Specifies if the initial values will be validated, when the component is loaded
+   */
+  validateOnLoad?: boolean;
 
   /**
    * The method is used to get the validation error message and determine whether the input value is valid or not.

--- a/src/controls/taxonomyPicker/TaxonomyPicker.tsx
+++ b/src/controls/taxonomyPicker/TaxonomyPicker.tsx
@@ -240,7 +240,6 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
  * @param node
  */
   private termsFromPickerChanged(terms: IPickerTerms) {
-    this.props.onChange(terms);
     this.setState({
       activeNodes: terms
     });


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes 612

#### What's in this Pull Request?
The error message is displayed correct with more than one invalid terms.
![Bild1_ errorMessageisalwasysdisplayed](https://user-images.githubusercontent.com/9026810/87336103-a6c9a380-c541-11ea-8b42-03bec3f13050.jpg)

Even though a correct term has been added, the error message must still display the invalid terms.
![Bild2_ errorMessageisalwasysdisplayed](https://user-images.githubusercontent.com/9026810/87336105-a7623a00-c541-11ea-8ea7-277b21faba80.jpg)

After an invalid term has been removed, the error message must display, which terms are still invalid.
![Bild3_ errorMessageisalwasysdisplayed](https://user-images.githubusercontent.com/9026810/87336106-a7623a00-c541-11ea-83c1-62801219d52b.jpg)

After all the invalid terms have been removed, the error message must not be displayed anymore.
![Bild4_ errorMessageisalwasysdisplayed](https://user-images.githubusercontent.com/9026810/87336107-a7fad080-c541-11ea-9fdf-6b5a7a03ba5a.jpg)

If a valid term has been selected with the taxonomy panel, the error message must display the invalid terms. 
![Bild5_ errorMessageisalwasysdisplayed](https://user-images.githubusercontent.com/9026810/87336111-a7fad080-c541-11ea-87ac-4a0e60b2dec8.jpg)

