### PR TITLE
TaxonomyPicker: Include check for separator while filtering path of terms when anchorId is configured

### DIFF
--- a/src/controls/taxonomyPicker/TermParent.tsx
+++ b/src/controls/taxonomyPicker/TermParent.tsx
@@ -37,9 +37,9 @@ export default class TermParent extends React.Component<ITermParentProps, ITermP
     {
       const anchorTerm = this._terms.filter(t => t.Id.toLowerCase() === this.props.anchorId.toLowerCase()).shift();
       if (anchorTerm) {
-        const anchorDepth = anchorTerm.PathDepth;
+        const anchorTermPath = anchorTerm.PathOfTerm + /* Append (;) separator, as a suffix to anchor term path. */ ';';
         this._anchorName = anchorTerm.Name;
-        var anchorTerms : ITerm[] = this._terms.filter(t => t.PathOfTerm.substring(0, anchorTerm.PathOfTerm.length) === anchorTerm.PathOfTerm && t.Id !== anchorTerm.Id);
+        let anchorTerms : ITerm[] = this._terms.filter(t => t.PathOfTerm.substring(0, anchorTermPath.length) === anchorTermPath && t.Id !== anchorTerm.Id);
 
         anchorTerms = anchorTerms.map(term => {
           term.PathDepth = term.PathDepth - anchorTerm.PathDepth;

--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -287,7 +287,6 @@ export default class SPTermStorePickerService {
       return null;
   }
 
-
   private searchTermsBySearchText(terms, searchText) {
     if (terms) {
       return terms.filter((t) => { return t.name.toLowerCase().indexOf(searchText.toLowerCase()) > -1; });
@@ -295,7 +294,6 @@ export default class SPTermStorePickerService {
     else
       return [];
   }
-
 
   public async searchTermsByTermId(searchText: string, termId: string): Promise<IPickerTerm[]> {
     if (Environment.type === EnvironmentType.Local) {
@@ -352,7 +350,8 @@ export default class SPTermStorePickerService {
       if (anchorId) {
         const anchorTerm = terms.filter(t => t.Id.toLowerCase() === anchorId.toLowerCase()).shift();
         if (anchorTerm) {
-          const anchorTerms: ITerm[] = terms.filter(t => t.PathOfTerm.substring(0, anchorTerm.PathOfTerm.length) === anchorTerm.PathOfTerm && t.Id !== anchorTerm.Id);
+          const anchorTermPath = anchorTerm.PathOfTerm + /* Append (;) separator, as a suffix to anchor term path. */ ';';
+          const anchorTerms : ITerm[] = terms.filter(t => t.PathOfTerm.substring(0, anchorTermPath.length) === anchorTermPath && t.Id !== anchorTerm.Id);
 
           anchorTerms.forEach(term => {
             returnTerms.push(this.convertTermToPickerTerm(term));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]

#### What's in this Pull Request?

Bug fix related to anchorId configuration inside TaxonomyPicker control - When anchorId is used with TaxonomyPicker control, and if there exists any other term (that is not as a child of anchor term and it starts with same name as the anchor term name), then that term becomes available in the terms listing. It should not be listed because it is not a child term.

**Bug Description**

Say, we have hierarchy of terms in the term store as follows:
![image](https://user-images.githubusercontent.com/46373637/88931394-71cd8880-d285-11ea-8b68-42d3043986ec.png)

Now if we configure TaxonomyPicker control to use "Helsinki" as anchorId, then TaxonomyPicker control shows results as follows:

1. While picking term from hierarchy listing
![image](https://user-images.githubusercontent.com/46373637/88932072-45fed280-d286-11ea-8077-b0415167103e.png)

2. While filtering terms via. type-in
![image](https://user-images.githubusercontent.com/46373637/88932061-426b4b80-d286-11ea-98d6-b8f590b0d1df.png)

If we check the hierarchy of terms inside the term store, then "Helsinki, Espoo, Vantaa" is not a child term of "Helsinki". So ideally, it should not be listed/populated inside our control.

This PR fixes above mentioned issue of TaxonomyPicker control.
