### PR TITLE
Added correction that taxonomy picker crashed when SharePoint return …

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -109,3 +109,5 @@ export const InvariantCulture: ICultureInfo = {
         eras: [1, 'A.D.', null, 0]
     }
 };
+
+export const EmptyGuid: string = "00000000-0000-0000-0000-000000000000";

--- a/src/controls/taxonomyPicker/TermPicker.tsx
+++ b/src/controls/taxonomyPicker/TermPicker.tsx
@@ -118,13 +118,7 @@ export default class TermPicker extends React.Component<ITermPickerProps, ITermP
         isTermSetSelectable
       } = this.props;
 
-      let terms: IPickerTerm[] = [];
-      if (termPickerHostProps.anchorId && termPickerHostProps.anchorId !== EmptyGuid) {
-        terms = await this.termsService.searchTermsByTermId(filterText, termPickerHostProps.anchorId,);
-      }
-      else {
-        terms = await this.termsService.searchTermsByName(filterText, termPickerHostProps.termsetNameOrID);
-      }
+      let terms: IPickerTerm[] = await this.termsService.searchTermsByName(filterText);
       // Check if the termset can be selected
       if (isTermSetSelectable && !termPickerHostProps.anchorId) {
         // Retrieve the current termset

--- a/src/controls/taxonomyPicker/TermPicker.tsx
+++ b/src/controls/taxonomyPicker/TermPicker.tsx
@@ -9,6 +9,7 @@ import * as strings from 'ControlStrings';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ExtensionContext } from '@microsoft/sp-extension-base';
 import { ITermSet } from "../../services/ISPTermStorePickerService";
+import { EmptyGuid } from '../../Common';
 
 export class TermBasePicker extends BasePicker<IPickerTerm, IBasePickerProps<IPickerTerm>>
 {
@@ -118,7 +119,7 @@ export default class TermPicker extends React.Component<ITermPickerProps, ITermP
       } = this.props;
 
       let terms: IPickerTerm[] = [];
-      if (termPickerHostProps.anchorId) {
+      if (termPickerHostProps.anchorId && termPickerHostProps.anchorId !== EmptyGuid) {
         terms = await this.termsService.searchTermsByTermId(filterText, termPickerHostProps.anchorId,);
       }
       else {

--- a/src/services/ISPTermStorePickerService.ts
+++ b/src/services/ISPTermStorePickerService.ts
@@ -80,3 +80,13 @@ export interface ITerm {
     [property: string]: any
   };
 }
+
+export interface ISuggestTerm {
+  Id: string;
+  DefaultLabel: string;
+  Description: string;
+  IsKeyword: boolean;
+  IsSynonym: boolean;
+  Paths: Array<string>;
+  Synonyms: string;
+}


### PR DESCRIPTION

Q | A
-- | --
Bug fix? | [ X ]
New feature? | [ ]
New sample? | [ ]
Related issues? | fixes #629, #288, #624, #604  


Following ticket #629, I found that a fix has been made on DEV branch. I tested but an issue appear when providing to parameter "AnchorId" the value that return SharePoint on loading list fields. The default response of SharePoint is empty GUID and not undefined, making the suggestion system crash. I added a check on that point to handle the case

Regards.