### PR TITLE
Update to FilePicker OrganisationAssetslibrary 

### DIFF
--- a/src/services/OrgAssetsService.ts
+++ b/src/services/OrgAssetsService.ts
@@ -73,7 +73,7 @@ export class OrgAssetsService extends FileBrowserService {
       absoluteUrl: this.buildAbsoluteUrl(libItem.LibraryUrl.DecodedUrl),
       title: libItem.DisplayName,
       serverRelativeUrl: libItem.LibraryUrl.DecodedUrl,
-      iconPath: libItem.ThumbnailUrl.DecodedUrl ? this.buildAbsoluteUrl(`${this._orgAssetsLibraryServerRelativeSiteUrl}/${libItem.ThumbnailUrl.DecodedUrl}`) : null
+      iconPath: libItem.ThumbnailUrl ? this.buildAbsoluteUrl(`${this._orgAssetsLibraryServerRelativeSiteUrl}/${libItem.ThumbnailUrl.DecodedUrl}`) : null
     };
 
     return orgAssetsLibrary;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Small change to the OrgAssetsService.ts.
if your organisationAssets library dosent have a thumbnail image, it will crash and not display your organisation library as the 
libItem.ThumbnailUrl will be null. 

Made a quick change to see if i null check the Thumbnail instead if that would fix the problem witch it does.
Would require some additional testing. But in my environment i did not get any errors after the change.

Also thanks to Rabia Williams for finding where the error happened.
