### PR TITLE
Fix/people search service profile picture image url

### DIFF
--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -229,10 +229,11 @@ export default class SPPeopleSearchService {
             switch (element.EntityType) {
               case 'User':
                 let email: string = element.EntityData.Email !== null ? element.EntityData.Email : element.Description;
+                const accountName = this.getAccountName(element);
                 return {
                   id: element.Key,
                   loginName: element.LoginName ? element.LoginName : element.Key,
-                  imageUrl: this.generateUserPhotoLink(email),
+                  imageUrl: this.generateUserPhotoLink(accountName),
                   imageInitials: this.getFullNameInitials(element.DisplayText),
                   text: element.DisplayText, // name
                   secondaryText: email, // email
@@ -307,6 +308,20 @@ export default class SPPeopleSearchService {
     }
 
     return null;
+  }
+
+  /**
+   * Gets account name for user, falls back to description
+   */
+  private getAccountName(element: any): string {
+    const loginName: string = element.LoginName || element.Key;
+    if (loginName) {
+      const loginParts: string[] = loginName.split("|");
+      if (loginParts.length > 0) {
+        return loginParts[loginParts.length - 1];
+      }
+    }
+    return element.Description || "";
   }
 
   /**

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -229,7 +229,8 @@ export default class SPPeopleSearchService {
             switch (element.EntityType) {
               case 'User':
                 let email: string = element.EntityData.Email !== null ? element.EntityData.Email : element.Description;
-                const accountName = this.getAccountName(element);
+                // Description contains the account name for a user
+                const accountName = element.Description || this.getAccountName(element);
                 return {
                   id: element.Key,
                   loginName: element.LoginName ? element.LoginName : element.Key,
@@ -311,7 +312,7 @@ export default class SPPeopleSearchService {
   }
 
   /**
-   * Gets account name for user, falls back to description
+   * Gets account name for user
    */
   private getAccountName(element: any): string {
     if (!element) { return ""; }
@@ -320,7 +321,8 @@ export default class SPPeopleSearchService {
       const loginParts: string[] = loginName.split("|");
       return loginParts[loginParts.length - 1];
     }
-    return element.Description || "";
+
+    return "";
   }
 
   /**

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -228,9 +228,8 @@ export default class SPPeopleSearchService {
           const userResults = values.map(element => {
             switch (element.EntityType) {
               case 'User':
-                let email: string = element.EntityData.Email !== null ? element.EntityData.Email : element.Description;
-                // Description contains the account name for a user
-                const accountName = element.Description || this.getAccountName(element);
+                const accountName: string =  element.Description || "";
+                const email: string  =  element.EntityData.Email || element.Description;
                 return {
                   id: element.Key,
                   loginName: element.LoginName ? element.LoginName : element.Key,
@@ -309,20 +308,6 @@ export default class SPPeopleSearchService {
     }
 
     return null;
-  }
-
-  /**
-   * Gets account name for user
-   */
-  private getAccountName(element: any): string {
-    if (!element) { return ""; }
-    const loginName: string = element.LoginName || element.Key;
-    if (loginName) {
-      const loginParts: string[] = loginName.split("|");
-      return loginParts[loginParts.length - 1];
-    }
-
-    return "";
   }
 
   /**

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -314,12 +314,11 @@ export default class SPPeopleSearchService {
    * Gets account name for user, falls back to description
    */
   private getAccountName(element: any): string {
+    if (!element) { return ""; }
     const loginName: string = element.LoginName || element.Key;
     if (loginName) {
       const loginParts: string[] = loginName.split("|");
-      if (loginParts.length > 0) {
-        return loginParts[loginParts.length - 1];
-      }
+      return loginParts[loginParts.length - 1];
     }
     return element.Description || "";
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?
Noticed that an image for a user picked in PeoplePicker didn't get resolved on my dev tenant for my test users even when they have profile picture set.
PeopleSearchService: 
Issue: The generateUserPhotoLink(value: string) method that resolves user's profile picture URL takes user's email address as an input parameter as the parameter for the accountName query string parameter. If users don't have email address set or email address does not match user's account name, image cannot be resolved.
Fix: using Description field from the response solves the issue. Description field contains user's account name.





