### PR TITLE
Feature: added additional props for File Picker

### DIFF
--- a/src/controls/filePicker/FilePicker.tsx
+++ b/src/controls/filePicker/FilePicker.tsx
@@ -206,7 +206,7 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
    * Closes the panel
    */
   private _handleClosePanel = () => {
-    if (this.props.onCancel !== undefined) {
+    if (this.props.onCancel) {
       this.props.onCancel();
     }
     this.setState({

--- a/src/controls/filePicker/FilePicker.tsx
+++ b/src/controls/filePicker/FilePicker.tsx
@@ -46,7 +46,7 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
     this.fileSearchService = new FilesSearchService(props.context, this.props.bingAPIKey);
 
     this.state = {
-      panelOpen: false,
+      panelOpen: this.props.isPanelOpen || false,
       organisationAssetsEnabled: false,
       showFullNav: true
     };

--- a/src/controls/filePicker/FilePicker.tsx
+++ b/src/controls/filePicker/FilePicker.tsx
@@ -206,6 +206,9 @@ export class FilePicker extends React.Component<IFilePickerProps, IFilePickerSta
    * Closes the panel
    */
   private _handleClosePanel = () => {
+    if (this.props.onCancel !== undefined) {
+      this.props.onCancel();
+    }
     this.setState({
       panelOpen: false
     });

--- a/src/controls/filePicker/IFilePickerProps.ts
+++ b/src/controls/filePicker/IFilePickerProps.ts
@@ -113,4 +113,12 @@ export interface IFilePickerProps {
    * @default true
    */
   storeLastActiveTab?: boolean;
+  /**
+   * Specifies if the file picker panel is open by default or not
+   */
+  isPanelOpen?: boolean;
+  /**
+   * Handler when file picker has been cancelled.
+   */
+  onCancel?: () => void;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | NA

#### What's in this Pull Request?

Added 2 additional properties to the file picker control.

1) isPanelOpen - this will directly open the file picker panel
2) onCancel - this will provide a callback when the file picker is cancelled. This was mentioned in #665 

Can you also add this to the v1 branch as well ? Let me know if I need to open a separate PR for the same. 