### PR TITLE
Feature/fix - changed API for OrgAssets items

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "gulp build",
     "clean": "gulp clean",
     "test": "gulp test",
+    "serve": "gulp serve",
     "prepublishOnly": "gulp",
     "versionUpdater": "gulp versionUpdater",
     "karma": "karma start --circle true",

--- a/src/services/OrgAssetsService.ts
+++ b/src/services/OrgAssetsService.ts
@@ -48,19 +48,19 @@ export class OrgAssetsService extends FileBrowserService {
 
   public getSiteMediaLibraries = async (includePageLibraries: boolean = false): Promise<ILibrary[]> => {
     try {
-      const restApi = `${this.context.pageContext.web.absoluteUrl}/_api/Microsoft.Online.SharePoint.TenantManagement.Office365Tenant/GetOrgAssets`;
+      const restApi = `${this.context.pageContext.web.absoluteUrl}/_api/SP.Publishing.SitePageService.FilePickerTabOptions`;
       const orgAssetsResult = await this.context.spHttpClient.get(restApi, SPHttpClient.configurations.v1);
 
       if (!orgAssetsResult || !orgAssetsResult.ok) {
         throw new Error(`Something went wrong when executing request. Status='${orgAssetsResult.status}'`);
       }
       const orgAssetsData = await orgAssetsResult.json();
-      if (!orgAssetsData || !orgAssetsData.OrgAssetsLibraries || !orgAssetsData.OrgAssetsLibraries.Items || orgAssetsData.OrgAssetsLibraries.Items.length <= 0) {
+      if (!orgAssetsData || !orgAssetsData.OrgAssets || !orgAssetsData.OrgAssets.OrgAssetsLibraries || !orgAssetsData.OrgAssets.OrgAssetsLibraries.Items || orgAssetsData.OrgAssets.OrgAssetsLibraries.Items.length <= 0) {
         return null;
       }
 
-      this._orgAssetsLibraryServerRelativeSiteUrl = orgAssetsData ? orgAssetsData.Url.DecodedUrl : null;
-      const libs: ILibrary[] = orgAssetsData ? orgAssetsData.OrgAssetsLibraries.Items.map((libItem) => { return this._parseOrgAssetsLibraryItem(libItem); }) : [];
+      this._orgAssetsLibraryServerRelativeSiteUrl = orgAssetsData ? orgAssetsData.OrgAssets.Url.DecodedUrl : null;
+      const libs: ILibrary[] = orgAssetsData && orgAssetsData.OrgAssets ? orgAssetsData.OrgAssets.OrgAssetsLibraries.Items.map((libItem) => { return this._parseOrgAssetsLibraryItem(libItem); }) : [];
       return libs;
     } catch (error) {
       console.error(`[OrgAssetsService.getOrganisationAssetsLibraries]: Err='${error.message}'`);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | not sure

#### What's in this Pull Request?

Have changed the API used to fetch Org Assets items. It is the same as the one used by Microsoft now.
The current API requires very high level permissions(SharePoint admin)  to access items from org asset libraries.
Using the API mentioned in the PR, this will be permission trimmed to the current user and not require SharePoint admin privileges. Using this any user with permissions to the libraries will be able to view the items.

Have targeted v2 branch, please let me know if you also need the same PR in v1 branch as well. Will be happy to submit it again for that !