### PR TITLE
Fix and restore ControlsTest.tsx references

### DIFF
--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -33,7 +33,7 @@ import { TermLabelAction, TermActionsDisplayMode } from '../../../controls/taxon
 import { ListItemAttachments } from '../../../ListItemAttachments';
 import { RichText } from '../../../RichText';
 import { Link } from 'office-ui-fabric-react/lib/components/Link';
-import { Carousel, CarouselButtonsLocation, CarouselButtonsDisplay, CarouselIndicatorShape } from '../../../controls/carousel';
+import { Carousel, CarouselButtonsLocation, CarouselButtonsDisplay, CarouselIndicatorShape, CarouselIndicatorsDisplay  } from '../../../controls/carousel';
 import { TimeDisplayControlType } from '../../../controls/dateTimePicker/TimeDisplayControlType';
 import { GridLayout } from '../../../GridLayout';
 import { ComboBoxListItemPicker } from '../../../controls/listItemPicker/ComboBoxListItemPicker';
@@ -61,6 +61,7 @@ import { Pagination } from '../../../controls/pagination';
 import CarouselImage from '../../../controls/carousel/CarouselImage';
 import { FieldCollectionData, CustomCollectionFieldType } from '../../../FieldCollectionData';
 import { Accordion } from '../../..';
+import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
 /**
  * The sample data below was randomly generated (except for the title). It is used by the grid layout
@@ -1188,6 +1189,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
             isInfinite={true}
             indicatorShape={CarouselIndicatorShape.circle}
+            indicatorsDisplay={CarouselIndicatorsDisplay.block}
             pauseOnHover={true}
 
             element={[
@@ -1218,6 +1220,9 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             ]}
             onMoveNextClicked={(index: number) => { console.log(`Next button clicked: ${index}`); }}
             onMovePrevClicked={(index: number) => { console.log(`Prev button clicked: ${index}`); }}
+            rootStyles={mergeStyles({
+              backgroundColor: '#C3C3C3'
+            })}
           />
         </div>
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

My last PR didnt have PR #681 changes in ControlsTest.tsx.
Restored references  ControlsTest.tsx that were removed from PR #682
I am sorry for this inconvenience.

`import { Carousel, CarouselButtonsLocation, CarouselButtonsDisplay, CarouselIndicatorShape, CarouselIndicatorsDisplay } from '../../../controls/carousel';`

`import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';`

`indicatorsDisplay={CarouselIndicatorsDisplay.block}`

            rootStyles={mergeStyles({
              backgroundColor: '#C3C3C3'
            })}

