### PR TITLE
Feature/fix - support special chars in folder name

### DIFF
--- a/src/services/FolderExplorerService.ts
+++ b/src/services/FolderExplorerService.ts
@@ -72,7 +72,7 @@ export class FolderExplorerService implements IFolderExplorerService {
     try {
       const web = Web(webAbsoluteUrl);
       folderRelativeUrl = folderRelativeUrl.replace(/\'/ig, "''");
-      let foldersResult: IFolder[] = await web.getFolderByServerRelativeUrl(folderRelativeUrl).folders.select('Name', 'ServerRelativeUrl').orderBy('Name').get();
+      let foldersResult: IFolder[] = await web.getFolderByServerRelativePath(encodeURIComponent(folderRelativeUrl)).folders.select('Name', 'ServerRelativeUrl').orderBy('Name').get();
       results = foldersResult.filter(f => f.Name != "Forms");
     } catch (error) {
       console.error('Error loading folders', error);
@@ -100,7 +100,8 @@ export class FolderExplorerService implements IFolderExplorerService {
     let folder: IFolder = null;
     try {
       const web = Web(webAbsoluteUrl);
-      let folderAddResult: IFolderAddResult = await web.getFolderByServerRelativeUrl(folderRelativeUrl).folders.add(name);
+      folderRelativeUrl = folderRelativeUrl.replace(/\'/ig, "''");
+      let folderAddResult: IFolderAddResult = await web.getFolderByServerRelativePath(encodeURIComponent(folderRelativeUrl)).folders.addUsingPath(encodeURIComponent(name));
       if (folderAddResult && folderAddResult.data) {
         folder = {
           Name: folderAddResult.data.Name,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | NA

#### What's in this Pull Request?

This PR fixes an issue with retrieving folder names containing single quotes as well as special chars like # and %.

This PR also add support to create folder names with special chars like # and % as we are using the new APIs like getFolderByServerRelativePath and addUsingPath.

Same PR as that done in property controls - https://github.com/pnp/sp-dev-fx-property-controls/pull/305