### PR TITLE
Sticky header on ListView

### DIFF
--- a/src/controls/listView/IListView.ts
+++ b/src/controls/listView/IListView.ts
@@ -63,6 +63,11 @@ export interface IListViewProps {
    * Specify the initial filter to be applied to the list.
    */
   defaultFilter?: string;
+    /**
+   * Boolean value to create a fixed/sticky header.
+   * Set to false by default
+   */
+  stickyHeader?: boolean;
 }
 
 export interface IListViewState {

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -60,6 +60,7 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
 
   constructor(props: IListViewProps) {
     super(props);
+    
     telemetry.track('ReactListView', {
       viewFields: !!props.viewFields,
       groupByFields: !!props.groupByFields,

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -835,7 +835,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           value={new Date()}
           onChange={(value) => console.log("DateTimePicker value:", value)}
           minDate={new Date("05/01/2019")}
-        maxDate={new Date("05/01/2020")} />
+          maxDate={new Date("05/01/2020")} />
 
         {/* <RichText isEditMode={this.props.displayMode === DisplayMode.Edit} onChange={value => { this.richTextValue = value; return value; }} /> */}
         <RichText isEditMode={this.props.displayMode === DisplayMode.Edit} onChange={value => { this.setState({ richTextValue: value }); return value; }} />
@@ -1352,7 +1352,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             ]}
             value={this.getRandomCollectionFieldData()}
           />
-          </div>
+        </div>
       </div>
     );
   }

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -835,7 +835,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           value={new Date()}
           onChange={(value) => console.log("DateTimePicker value:", value)}
           minDate={new Date("05/01/2019")}
-          maxDate={new Date("05/01/2020")} />
+        maxDate={new Date("05/01/2020")} />
 
         {/* <RichText isEditMode={this.props.displayMode === DisplayMode.Edit} onChange={value => { this.richTextValue = value; return value; }} /> */}
         <RichText isEditMode={this.props.displayMode === DisplayMode.Edit} onChange={value => { this.setState({ richTextValue: value }); return value; }} />
@@ -975,6 +975,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           showFilter={true}
           dragDropFiles={true}
           onDrop={this._getDropFiles}
+          stickyHeader={true}
         // defaultFilter="Team"
         />
 
@@ -1351,7 +1352,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             ]}
             value={this.getRandomCollectionFieldData()}
           />
-        </div>
+          </div>
       </div>
     );
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ X]
| New sample?      | [ ]
| Related issues?  | mentioned in #634 

#### What's in this Pull Request?

Added the ability of a fixed header. (https://developer.microsoft.com/en-us/fluentui#/controls/web/scrollablepane)
Both searchbox and headers stay locked during scrolling.

_Property added:_
- stickyHeader (boolean - default false) => Show fixed headers.

_Remarque:_
- Scrollable pane has a fixed height.

![sticky_header](https://user-images.githubusercontent.com/36161889/95770439-af08ba80-0cb9-11eb-9cf6-2bd7f18a1fa0.PNG)
