### PR TITLE
Treeview child nodes expand/collapse

### DIFF
--- a/src/controls/treeView/ITreeViewProps.ts
+++ b/src/controls/treeView/ITreeViewProps.ts
@@ -67,4 +67,9 @@ export interface ITreeViewProps {
    * @argument item The tree item.
    */
   onRenderItem?: (item: ITreeItem) => JSX.Element;
+   /**
+   * Default expand / collapse behavior for the child nodes.
+   * By default this is set to true.
+   */
+  defaultExpandedChildren?: boolean;
 }

--- a/src/controls/treeView/TreeItem.tsx
+++ b/src/controls/treeView/TreeItem.tsx
@@ -61,6 +61,10 @@ export interface ITreeItemProps {
   onRenderItem?: (item: ITreeItem) => JSX.Element;
 
   nodesToExpand: any[];
+   /**
+   * Specifies whether current tree item's children should be rendered as expanded.
+   */
+  defaultExpandedChildren?: boolean;
 }
 
 
@@ -217,14 +221,18 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
         parentCallbackOnSelect,
         onRenderItem,
         showCheckboxes,
-        treeItemActionsDisplayMode
+        treeItemActionsDisplayMode,
+        defaultExpandedChildren
       } = this.props;
+
+      const { expanded } = this.state;
 
       let childrenWithHandlers = list.map((item, index) => {
         return (
           <TreeItem
             treeItem={item}
-            defaultExpanded={this.state.expanded}
+            defaultExpanded={defaultExpandedChildren ? expanded : expanded && !item.hasOwnProperty('children')}
+            defaultExpandedChildren={defaultExpandedChildren}
             leftOffset={paddingLeft}
             selectionMode={selectionMode}
             activeItems={activeItems}

--- a/src/controls/treeView/TreeView.tsx
+++ b/src/controls/treeView/TreeView.tsx
@@ -203,10 +203,11 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
       onRenderItem,
       showCheckboxes,
       treeItemActionsDisplayMode,
-      defaultExpanded
+      defaultExpanded,
+      defaultExpandedChildren
     } = this.props;
 
-    return (
+      return (
       <div className={styles.treeView}>
         {
           items.map((treeNodeItem, index) => (
@@ -215,6 +216,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
               leftOffset={20}
               isFirstRender={true}
               defaultExpanded={defaultExpanded}
+              defaultExpandedChildren={defaultExpandedChildren !== undefined ? defaultExpandedChildren : true}
               selectionMode={selectionMode}
               activeItems={this.state.activeItems}
               parentCallbackExpandCollapse={this.handleTreeExpandCollapse}

--- a/src/controls/treeView/TreeView.tsx
+++ b/src/controls/treeView/TreeView.tsx
@@ -207,7 +207,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
       defaultExpandedChildren
     } = this.props;
 
-      return (
+    return (
       <div className={styles.treeView}>
         {
           items.map((treeNodeItem, index) => (

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -1311,7 +1311,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             onSelect={this._onFolderSelect}
             canCreateFolders={true}
           />
-          </div>
+        </div>
 
         <div>
           <h3>Tree View</h3>
@@ -1359,7 +1359,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             ]}
             value={this.getRandomCollectionFieldData()}
           />
-          </div>
+        </div>
       </div>
     );
   }

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -271,7 +271,13 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           children: [
             {
               key: "gc3",
-              label: "Child of Parent 10"
+              label: "Child of Parent 10",
+              children: [
+                {
+                  key: "ggc1",
+                  label: "Grandchild of Parent 10"
+                }
+              ]
             },
           ]
         },
@@ -1305,7 +1311,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             onSelect={this._onFolderSelect}
             canCreateFolders={true}
           />
-        </div>
+          </div>
 
         <div>
           <h3>Tree View</h3>
@@ -1317,7 +1323,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             defaultSelectedKeys={['gc1', 'gc3']}
             onExpandCollapse={this.onExpandCollapseTree}
             onSelect={this.onItemSelected}
-          //expandToSelected={true}
+            defaultExpandedChildren={true}
+            //expandToSelected={true}
           // onRenderItem={this.renderCustomTreeItem}
           />
 
@@ -1352,7 +1359,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             ]}
             value={this.getRandomCollectionFieldData()}
           />
-        </div>
+          </div>
       </div>
     );
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | mentioned in #677 

#### What's in this Pull Request?

**Question** : When I expand a parent node, all the child nodes are expanded. I would like to know, if there is any property available to disable this behavior. The child nodes need to be in collapsed state and the user should expand them

**Solution** : Added (optional) property 'defaultExpandedChildren' that controls the behavior of the expansion of child elements.
if defaultExpandedChildren is set to false --> only the parent elements will be shown. (img. 1)
if defaultExpandedChildren is set to true --> all underlying child elements will be shown. (img. 2)

![d1c0](https://user-images.githubusercontent.com/36161889/96150976-36993800-0f0b-11eb-875e-ef7ff7063d03.PNG)

![d1c1](https://user-images.githubusercontent.com/36161889/96151015-41ec6380-0f0b-11eb-9c77-5aa6ea55c08b.PNG)


