### PR TITLE
Add filesize to FilePicker component

### DIFF
--- a/docs/documentation/docs/controls/FilePicker.md
+++ b/docs/documentation/docs/controls/FilePicker.md
@@ -86,6 +86,7 @@ Provides options for carousel buttons location.
 | fileName | string | File name of the result with the extension. |
 | fileNameWithoutExtension | string | File name of the result without the extension. |
 | fileAbsoluteUrl | string | Absolute URL of the file. Null in case of file upload. |
+| fileSize | number | Size of the result (in bytes). Set only for file upload |
 | downloadFileContent | () => Promise<File> | Function allows to download file content. Returns File object. |
 
 

--- a/src/controls/filePicker/FilePicker.types.ts
+++ b/src/controls/filePicker/FilePicker.types.ts
@@ -33,6 +33,11 @@ export interface IFilePickerResult {
   fileAbsoluteUrl: string;
 
   /**
+   * Size of a selected file (in bytes). Undefined in all cases but file upload 
+   */
+  fileSize?: number;
+
+  /**
    * Absolute not modified file SharePoint URL.
    */
   spItemUrl?: string;

--- a/src/controls/filePicker/UploadFilePickerTab/UploadFilePickerTab.tsx
+++ b/src/controls/filePicker/UploadFilePickerTab/UploadFilePickerTab.tsx
@@ -81,6 +81,7 @@ export default class UploadFilePickerTab extends React.Component<IUploadFilePick
     const filePickerResult: IFilePickerResult = {
       fileAbsoluteUrl: null,
       fileName: file.name,
+      fileSize: file.size,
       fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(file.name),
       downloadFileContent: () => { return Promise.resolve(file); }
     };

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -1279,7 +1279,12 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           {
             this.state.filePickerResult &&
             <div>
-              FileName: {this.state.filePickerResult.fileName}
+              <div>
+                FileName: {this.state.filePickerResult.fileName}
+              </div>
+              <div>
+                File size: {this.state.filePickerResult.fileSize}
+              </div>
             </div>
           }
         </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | mentioned in #699

#### What's in this Pull Request?

Pull request adds file size to IFilePickerResult interface, which allows to inspect file size of selected file without having to execute downloadFileContent(). Works only for upload file tab.