### PR TITLE
TaxonomyPicker: Show an error message for an invalid/unresolved input

### DIFF
--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -85,6 +85,11 @@ export interface ITaxonomyPickerProps  {
   validateOnLoad?: boolean;
 
   /**
+   * Specifies if the input text will be validated, when the component focus is changed
+   */
+  validateInput?: boolean;
+
+  /**
    * The method is used to get the validation error message and determine whether the input value is valid or not.
    * Mutually exclusive with the static string errorMessage (it will take precedence over this).
    *

--- a/src/controls/taxonomyPicker/TermPicker.tsx
+++ b/src/controls/taxonomyPicker/TermPicker.tsx
@@ -10,6 +10,7 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ExtensionContext } from '@microsoft/sp-extension-base';
 import { ITermSet } from "../../services/ISPTermStorePickerService";
 import { EmptyGuid } from '../../Common';
+import { Autofill } from 'office-ui-fabric-react/lib/components/Autofill/Autofill';
 
 export class TermBasePicker extends BasePicker<IPickerTerm, IBasePickerProps<IPickerTerm>>
 {
@@ -32,6 +33,8 @@ export interface ITermPickerProps {
   placeholder?: string;
 
   onChanged: (items: IPickerTerm[]) => void;
+  onInputChange: (input: string) => string;
+  onBlur: (ev: React.FocusEvent<HTMLElement | Autofill>) => void;
 }
 
 export default class TermPicker extends React.Component<ITermPickerProps, ITermPickerState> {
@@ -183,7 +186,6 @@ export default class TermPicker extends React.Component<ITermPickerProps, ITermP
     }
   }
 
-
   /**
    * gets the text from an item
    */
@@ -191,7 +193,7 @@ export default class TermPicker extends React.Component<ITermPickerProps, ITermP
     return item.name;
   }
 
-    /**
+  /**
    * Render method
    */
   public render(): JSX.Element {
@@ -199,6 +201,8 @@ export default class TermPicker extends React.Component<ITermPickerProps, ITermP
       disabled,
       value,
       onChanged,
+      onInputChange,
+      onBlur,
       allowMultipleSelections,
       placeholder
     } = this.props;
@@ -218,6 +222,8 @@ export default class TermPicker extends React.Component<ITermPickerProps, ITermP
           defaultSelectedItems={value}
           selectedItems={terms}
           onChange={onChanged}
+          onInputChange={onInputChange}
+          onBlur={onBlur}
           itemLimit={!allowMultipleSelections ? 1 : undefined}
           className={styles.termBasePicker}
           inputProps={{

--- a/src/loc/en-us.ts
+++ b/src/loc/en-us.ts
@@ -46,6 +46,7 @@ define([], () => {
     "TaxonomyPickerInLabel": "in",
     "TaxonomyPickerTermSetLabel": "Term Set",
     "TaxonomyPickerTermsNotFound": "The next selected term(s) could not be found in the term store: {0}",
+    "TaxonomyPickerInvalidTerms": "Please fix invalid term(s): {0}",
 
     peoplePickerComponentTooltipMessage: "People Picker",
     peoplePickerComponentErrorMessage: "Required Field",

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -27,6 +27,7 @@ declare interface IControlStrings {
   TaxonomyPickerInLabel: string;
   TaxonomyPickerTermSetLabel: string;
   TaxonomyPickerTermsNotFound: string;
+  TaxonomyPickerInvalidTerms: string;
 
   ListItemPickerSelectValue: string;
 

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -730,6 +730,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             onChange={this.onServicePickerChange}
             isTermSetSelectable={false}
             placeholder="Select service"
+            // validateInput={true}   /* Uncomment this to enable validation of input text */
             required={true}
             errorMessage='this field is required'
             onGetErrorMessage={(value) => { return 'comment errorMessage to see this one'; }}


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| Enhancement?    | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #728

#### What's in this Pull Request?
Provides ability to optionally show an error message beneath the taxonomy picker control for any invalid input entered by the user. 

#### Implementation Details
The input validation will happen based on newly introduced property named **"validateInput"** of type boolean. 
- If set to **true**, then an error message **[Please fix invalid term(s)]** will be shown for any invalid input. 
- If set to **false** or **not defined**, then it will continue to work as it works currently (i.e., no error message will be displayed).

#### Usage 
In order to enable input text validation, you need to set **`validateInput={true}`** property of **`<TaxonomyPicker />`** control.

![image](https://user-images.githubusercontent.com/46373637/98804708-2b103280-241f-11eb-8b07-a24a2881fcb7.png)


