### PR TITLE
Remove deprecated stuff

### DIFF
--- a/src/controls/dateTimePicker/SecondsComponent.tsx
+++ b/src/controls/dateTimePicker/SecondsComponent.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { ITimeComponentProps } from './ITimeComponentProps';
 import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
 import { TimeHelper } from './TimeHelper';
-import { disableBodyScroll } from '@uifabric/utilities/lib';
 import { IDropdownOption, Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
 import { TimeDisplayControlType } from './TimeDisplayControlType';
 

--- a/src/controls/fields/fieldFileTypeRenderer/FieldFileTypeRenderer.tsx
+++ b/src/controls/fields/fieldFileTypeRenderer/FieldFileTypeRenderer.tsx
@@ -7,7 +7,6 @@ import { FileTypeIcon, IconType } from '../../fileTypeIcon';
 import * as telemetry from '../../../common/telemetry';
 
 import styles from './FieldFileTypeRenderer.module.scss';
-import { findIndex } from '@microsoft/sp-lodash-subset';
 
 export interface IFieldFileTypeRendererProps extends IFieldRendererProps {
   /**

--- a/src/controls/fields/fieldUserRenderer/FieldUserRenderer.tsx
+++ b/src/controls/fields/fieldUserRenderer/FieldUserRenderer.tsx
@@ -16,7 +16,6 @@ import { IFieldRendererProps } from '../fieldCommon/IFieldRendererProps';
 import styles from './FieldUserRenderer.module.scss';
 import { IContext } from '../../../common/Interfaces';
 import { GeneralHelper } from '../../../common/utilities/GeneralHelper';
-import { SPHttpClient } from '@microsoft/sp-http';
 import FieldUserHoverCard, { IFieldUserHoverCardProps } from './FieldUserHoverCard';
 import * as telemetry from '../../../common/telemetry';
 

--- a/src/controls/filePicker/controls/DocumentTile/DocumentTile.tsx
+++ b/src/controls/filePicker/controls/DocumentTile/DocumentTile.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from './DocumentTile.module.scss';
-import { css, IRenderFunction, IRectangle } from 'office-ui-fabric-react/lib/Utilities';
-import { Image, IImageProps, ImageFit } from 'office-ui-fabric-react/lib/Image';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
 import * as strings from 'ControlStrings';
 import { Check } from 'office-ui-fabric-react/lib/Check';
 import { ScreenWidthMinLarge } from 'office-ui-fabric-react/lib/Styling';

--- a/src/controls/filePicker/controls/FileBrowser/IFileBrowserState.ts
+++ b/src/controls/filePicker/controls/FileBrowser/IFileBrowserState.ts
@@ -1,6 +1,6 @@
 import { ViewType } from ".";
 import { IFile } from "../../../../services/FileBrowserService.types";
-import { Selection, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { IFilePickerResult } from "../../FilePicker.types";
 
 export enum LoadingState {

--- a/src/controls/filePicker/controls/FolderTile/FolderTile.tsx
+++ b/src/controls/filePicker/controls/FolderTile/FolderTile.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from './FolderTile.module.scss';
-import { css, IRenderFunction, IRectangle } from 'office-ui-fabric-react/lib/Utilities';
-import { Icon, IconType } from 'office-ui-fabric-react/lib/Icon';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import * as strings from 'ControlStrings';
 import { ScreenWidthMinLarge  } from 'office-ui-fabric-react/lib/Styling';
 import { IFolderTileProps } from './IFolderTileProps';
@@ -44,8 +44,7 @@ export class FolderTile extends React.Component<IFolderTileProps> {
                   <div
                     className={css(styles.folderCover, styles.isLarge)}>
                     <Icon
-                      className={styles.folderCoverBack}
-                      iconType={IconType.image}
+                      className={styles.folderCoverBack}                      
                       imageProps={{
                         src: strings.FolderBackPlate
                       }} />
@@ -58,8 +57,7 @@ export class FolderTile extends React.Component<IFolderTileProps> {
                       </span>
                     }
                     <Icon
-                      className={styles.folderCoverFront}
-                      iconType={IconType.image}
+                      className={styles.folderCoverFront}                      
                       imageProps={{
                         src: strings.FolderFrontPlate
                       }} />

--- a/src/controls/filePicker/controls/TilesList/ITilesListProps.ts
+++ b/src/controls/filePicker/controls/TilesList/ITilesListProps.ts
@@ -1,6 +1,6 @@
 import { FileBrowserService } from "../../../../services/FileBrowserService";
 import { IFile } from "../../../../services/FileBrowserService.types";
-import { SelectionZone, ISelection, Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
+import { Selection } from 'office-ui-fabric-react/lib/Selection';
 import { IFilePickerResult } from "../../FilePicker.types";
 
 export interface ITilesListProps {

--- a/src/controls/filePicker/controls/TilesList/TilesList.tsx
+++ b/src/controls/filePicker/controls/TilesList/TilesList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styles from './TilesList.module.scss';
-import { SelectionZone, ISelection, Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
+import { SelectionZone } from 'office-ui-fabric-react/lib/Selection';
 import { IFile } from '../../../../services/FileBrowserService.types';
 import { List, IPageProps } from 'office-ui-fabric-react/lib/List';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';

--- a/src/controls/fileTypeIcon/FileTypeIcon.tsx
+++ b/src/controls/fileTypeIcon/FileTypeIcon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { findIndex } from '@microsoft/sp-lodash-subset';
 import { IFileTypeIconProps, ApplicationType, ApplicationIconList, IconType, IconSizes, ImageSize, IImageResult, ICON_GENERIC_16, ICON_GENERIC_48, ICON_GENERIC_96, ImageInformation } from './IFileTypeIcon';
 import * as telemetry from '../../common/telemetry';
-import { Icon, IconType as IconUIType } from 'office-ui-fabric-react/lib/components/Icon';
+import { Icon } from 'office-ui-fabric-react/lib/components/Icon';
 import * as styles from './FileTypeIcon.module.scss';
 
 const ICON_GENERIC = 'Page';
@@ -226,25 +226,25 @@ export class FileTypeIcon extends React.Component<IFileTypeIconProps, {}> {
       // Check if the image was found, otherwise a generic image will be returned
       if (iconImage.cdnFallback) {
         const iconUrl = `${ICON_CDN_URL}/${iconImage.size.replace("icon", "")}/${iconImage.cdnFallback}.png`;
-        iconElm = <Icon iconType={IconUIType.image} imageProps={{ src: iconUrl }} />;
+        iconElm = <Icon imageProps={{ src: iconUrl }} />;
       } else if (iconImage.image) {
-        iconElm = <Icon iconType={IconUIType.image} imageProps={{ className: `ms-BrandIcon--${iconImage.size} ms-BrandIcon--${iconImage.image}` }} />;
+        iconElm = <Icon imageProps={{ className: `ms-BrandIcon--${iconImage.size} ms-BrandIcon--${iconImage.image}` }} />;
       } else {
         // Return a generic image
         let imgElm = <img />;
         // Check the size of the generic image which has to be returned
         switch (iconImage.size) {
           case 'icon16':
-          imgElm = <Icon iconType={IconUIType.image} imageProps={{ src: ICON_GENERIC_16 }} />;
+          imgElm = <Icon imageProps={{ src: ICON_GENERIC_16 }} />;
           break;
           case 'icon48':
-          imgElm = <Icon iconType={IconUIType.image} imageProps={{ src: ICON_GENERIC_48}} />;
+          imgElm = <Icon imageProps={{ src: ICON_GENERIC_48}} />;
           break;
           case 'icon96':
-          imgElm = <Icon iconType={IconUIType.image} imageProps={{ src: ICON_GENERIC_96}} />;
+          imgElm = <Icon imageProps={{ src: ICON_GENERIC_96}} />;
           break;
           default:
-          imgElm = <Icon iconType={IconUIType.image} imageProps={{ src: ICON_GENERIC_16}} />;
+          imgElm = <Icon imageProps={{ src: ICON_GENERIC_16}} />;
           break;
         }
 

--- a/src/controls/folderExplorer/FolderExplorer/FolderExplorer.tsx
+++ b/src/controls/folderExplorer/FolderExplorer/FolderExplorer.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { TextField } from "office-ui-fabric-react/lib/TextField";
 import styles from './FolderExplorer.module.scss';
 import * as strings from 'ControlStrings';
 import { Icon } from "office-ui-fabric-react/lib/Icon";

--- a/src/controls/iconPicker/IconPicker.tsx
+++ b/src/controls/iconPicker/IconPicker.tsx
@@ -6,7 +6,6 @@ import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { IRenderFunction, getId } from 'office-ui-fabric-react/lib/Utilities';
 import styles from './IconPicker.module.scss';
 import * as strings from 'ControlStrings';
-import { IconNames } from './IconNames';
 import { Panel, PanelType, IPanelProps } from 'office-ui-fabric-react/lib/Panel';
 import debounce from 'lodash/debounce';
 import { IIconPickerState } from './IIconPickerState';

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import styles from './ListView.DragDrop.module.scss';
 import stickyHeaderstyles from './ListView.stickyHeader.module.scss';
-import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IGroup, IDetailsHeaderProps } from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IGroup } from 'office-ui-fabric-react/lib/DetailsList';
 import { IListViewProps, IListViewState, IViewField, IGrouping, GroupOrder } from './IListView';
-import { IColumn, IGroupRenderProps, IObjectWithKey } from 'office-ui-fabric-react/lib/components/DetailsList';
+import { IColumn, IGroupRenderProps } from 'office-ui-fabric-react/lib/components/DetailsList';
 import { findIndex, has, sortBy, isEqual, cloneDeep } from '@microsoft/sp-lodash-subset';
 import { FileTypeIcon, IconType } from '../fileTypeIcon/index';
 import * as strings from 'ControlStrings';

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -9,7 +9,6 @@ import { NormalPeoplePicker } from 'office-ui-fabric-react/lib/components/picker
 import { Label } from 'office-ui-fabric-react/lib/components/Label';
 import { IBasePickerSuggestionsProps } from "office-ui-fabric-react/lib/components/pickers/BasePicker.types";
 import { IPersonaProps } from "office-ui-fabric-react/lib/components/Persona/Persona.types";
-import { Icon } from "office-ui-fabric-react/lib/components/Icon";
 import FieldErrorMessage from '../errorMessage/ErrorMessage';
 import isEqual from 'lodash/isEqual';
 import uniqBy from 'lodash/uniqBy';

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -1,6 +1,6 @@
 import { IPickerTerms } from './ITermPicker';
 import { ITermSet, ITerm } from '../../services/ISPTermStorePickerService';
-import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { WebPartContext } from '@microsoft/sp-webpart-base';
 import { ITermActions } from './termActions/ITermsActions';
 import SPTermStorePickerService from '../../services/SPTermStorePickerService';
 import { ExtensionContext } from '@microsoft/sp-extension-base';
@@ -28,7 +28,7 @@ export interface ITaxonomyPickerProps  {
   /**
    * WebPart's context
    */
-  context: IWebPartContext | ExtensionContext;
+  context: WebPartContext | ExtensionContext;
   /**
    * Limit the terms that can be picked by the Term Set name or ID
    */

--- a/src/controls/taxonomyPicker/ITermPicker.ts
+++ b/src/controls/taxonomyPicker/ITermPicker.ts
@@ -1,4 +1,4 @@
-import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { WebPartContext } from '@microsoft/sp-webpart-base';
 import { ExtensionContext } from '@microsoft/sp-extension-base';
 
 /**
@@ -41,7 +41,7 @@ export interface IPropertyFieldTermPickerProps {
   /**
    * WebPart's context
    */
-  context: IWebPartContext | ExtensionContext;
+  context: WebPartContext | ExtensionContext;
   /**
    * Limit the term sets that can be used by the group name or ID
    */

--- a/src/controls/taxonomyPicker/TaxonomyPicker.tsx
+++ b/src/controls/taxonomyPicker/TaxonomyPicker.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PrimaryButton, DefaultButton, IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
-import { Spinner, SpinnerType } from 'office-ui-fabric-react/lib/Spinner';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import TermPicker from './TermPicker';
 import { IPickerTerms, IPickerTerm } from './ITermPicker';
@@ -448,7 +448,7 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
 
           {
             /* Show spinner in the panel while retrieving terms */
-            loaded === false ? <Spinner type={SpinnerType.normal} /> : ''
+            loaded === false ? <Spinner size={SpinnerSize.medium} /> : ''
           }
           {
             loaded === true && termSetAndTerms && (

--- a/src/controls/taxonomyPicker/TermParent.tsx
+++ b/src/controls/taxonomyPicker/TermParent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Spinner, SpinnerType } from 'office-ui-fabric-react/lib/Spinner';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import { ITermParentProps, ITermParentState } from './ITaxonomyPicker';
 import { ITerm } from '../../services/ISPTermStorePickerService';
 import { EXPANDED_IMG, COLLAPSED_IMG, TERMSET_IMG, TERM_IMG } from './TaxonomyPicker';
@@ -125,7 +125,7 @@ export default class TermParent extends React.Component<ITermParentProps, ITermP
         termElm = <div className={`${styles.listItem} ${styles.term}`}>{strings.TaxonomyPickerNoTerms}</div>;
       }
     } else {
-      termElm = <Spinner type={SpinnerType.normal} />;
+      termElm = <Spinner size={SpinnerSize.medium} />;
     }
 
 

--- a/src/controls/taxonomyPicker/TermPicker.tsx
+++ b/src/controls/taxonomyPicker/TermPicker.tsx
@@ -4,12 +4,11 @@ import { IPickerTerm, IPickerTerms } from './ITermPicker';
 import SPTermStorePickerService from './../../services/SPTermStorePickerService';
 import styles from './TaxonomyPicker.module.scss';
 import { ITaxonomyPickerProps } from './ITaxonomyPicker';
-import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { WebPartContext } from '@microsoft/sp-webpart-base';
 import * as strings from 'ControlStrings';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ExtensionContext } from '@microsoft/sp-extension-base';
 import { ITermSet } from "../../services/ISPTermStorePickerService";
-import { EmptyGuid } from '../../Common';
 
 export class TermBasePicker extends BasePicker<IPickerTerm, IBasePickerProps<IPickerTerm>>
 {
@@ -22,7 +21,7 @@ export interface ITermPickerState {
 
 export interface ITermPickerProps {
   termPickerHostProps: ITaxonomyPickerProps;
-  context: IWebPartContext | ExtensionContext;
+  context: WebPartContext | ExtensionContext;
   disabled: boolean;
   value: IPickerTerms;
   allowMultipleSelections : boolean;

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -1,4 +1,4 @@
-import { ISPHttpClientOptions, SPHttpClient, SPHttpClientResponse } from '@microsoft/sp-http';
+import { ISPHttpClientOptions, SPHttpClient } from '@microsoft/sp-http';
 import { Environment, EnvironmentType } from '@microsoft/sp-core-library';
 import { WebPartContext } from '@microsoft/sp-webpart-base';
 import { ExtensionContext } from '@microsoft/sp-extension-base';

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -2,7 +2,7 @@ import { ISPService, ILibsOptions, LibsOrderBy } from "./ISPService";
 import { ISPLists } from "../common/SPEntities";
 import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { ExtensionContext } from "@microsoft/sp-extension-base";
-import { SPHttpClient, SPHttpClientResponse, ISPHttpClientOptions } from "@microsoft/sp-http";
+import { SPHttpClient, ISPHttpClientOptions } from "@microsoft/sp-http";
 
 export default class SPService implements ISPService {
 

--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -7,7 +7,7 @@
 
 import { SPHttpClient, SPHttpClientResponse, ISPHttpClientOptions } from '@microsoft/sp-http';
 import { Environment, EnvironmentType } from '@microsoft/sp-core-library';
-import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { WebPartContext } from '@microsoft/sp-webpart-base';
 import { ITaxonomyPickerProps } from '../controls/taxonomyPicker/ITaxonomyPicker';
 import { IPickerTerm } from '../controls/taxonomyPicker/ITermPicker';
 import { ITermStore, ITerms, ITerm, IGroup, ITermSet, ISuggestTerm } from './ISPTermStorePickerService';
@@ -29,7 +29,7 @@ export default class SPTermStorePickerService {
   /**
    * Service constructor
    */
-  constructor(private props: ITaxonomyPickerProps, private context: IWebPartContext | ExtensionContext) {
+  constructor(private props: ITaxonomyPickerProps, private context: WebPartContext | ExtensionContext) {
     if (Environment.type !== EnvironmentType.Local) {
       {
         this.clientServiceUrl = this.context.pageContext.web.absoluteUrl + '/_vti_bin/client.svc/ProcessQuery';


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | NA

#### What's in this Pull Request?

This PR 

1) Removes some unused imports.
2) Since the upgrade to SPFx 1.11 and minor fabric upgrade, there were some deprecated imports we were using , so fixed them. They are mostly related to Spinner and Icon components. Also, removed the `IWebpartContext` and used the `WebpartContext`