### PR TITLE
Better handling of session storage values

### DIFF
--- a/src/common/utilities/SPHelper.ts
+++ b/src/common/utilities/SPHelper.ts
@@ -385,16 +385,28 @@ export class SPHelper {
     }
 
     private static _updateSessionStorageLoadedViewFields(loadedViewFields: { [viewId: string]: IFields }): void {
-        const sessionStorage: any = window.sessionStorage;
-        sessionStorage.setItem(Constants.LoadedViewFieldsKey, JSON.stringify(loadedViewFields));
+        try {
+            if (window.sessionStorage) {
+                window.sessionStorage.setItem(Constants.LoadedViewFieldsKey, JSON.stringify(loadedViewFields));
+            }
+        } catch (error) {
+            // do nothing, no need to stop fn execution
+        }
     }
 
     private static _getLoadedViewFieldsFromStorage(): { [viewId: string]: IFields } {
-        const loadedViewFields = sessionStorage.getItem(Constants.LoadedViewFieldsKey);
-        if (loadedViewFields) {
-            return JSON.parse(loadedViewFields);
+        try {
+            if (window.sessionStorage) {
+                const loadedViewFields = sessionStorage.getItem(Constants.LoadedViewFieldsKey);
+                if (loadedViewFields) {
+                    return JSON.parse(loadedViewFields);
+                }
+            }
+            else {
+                return null;
+            }
+        } catch (error) {
+            return null;
         }
-
-        return null;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | NA

#### What's in this Pull Request?

Sometimes due to large number of items in the session storage, we get error about quota exceeded. This happened once due to large number of items in the Taxonomy picker as well which caused the picker not work. 
So, added a try catch block to prevent this.

Credit to @poikjo for finding the issue.