### PR TITLE
Fix FolderExplorer pnpjs related issues

### DIFF
--- a/src/services/FolderExplorerService.ts
+++ b/src/services/FolderExplorerService.ts
@@ -6,6 +6,7 @@ import { sp } from "@pnp/sp";
 import "@pnp/sp/webs";
 import { Web } from "@pnp/sp/webs";
 import "@pnp/sp/folders";
+import "@pnp/sp/lists";
 import { IFolderAddResult } from "@pnp/sp/folders";
 
 export class FolderExplorerService implements IFolderExplorerService {
@@ -72,7 +73,7 @@ export class FolderExplorerService implements IFolderExplorerService {
     try {
       const web = Web(webAbsoluteUrl);
       folderRelativeUrl = folderRelativeUrl.replace(/\'/ig, "''");
-      let foldersResult: IFolder[] = await web.getFolderByServerRelativePath(encodeURIComponent(folderRelativeUrl)).folders.select('Name', 'ServerRelativeUrl').orderBy('Name').get();
+      let foldersResult: IFolder[] = await web.getFolderByServerRelativePath(folderRelativeUrl).folders.select('Name', 'ServerRelativeUrl').orderBy('Name').get();
       results = foldersResult.filter(f => f.Name != "Forms");
     } catch (error) {
       console.error('Error loading folders', error);
@@ -101,7 +102,7 @@ export class FolderExplorerService implements IFolderExplorerService {
     try {
       const web = Web(webAbsoluteUrl);
       folderRelativeUrl = folderRelativeUrl.replace(/\'/ig, "''");
-      let folderAddResult: IFolderAddResult = await web.getFolderByServerRelativePath(encodeURIComponent(folderRelativeUrl)).folders.addUsingPath(encodeURIComponent(name));
+      let folderAddResult: IFolderAddResult = await web.getFolderByServerRelativePath(folderRelativeUrl).folders.addUsingPath(encodeURIComponent(name));
       if (folderAddResult && folderAddResult.data) {
         folder = {
           Name: folderAddResult.data.Name,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #741 

#### What's in this Pull Request?

probably pnpjs version related fixes

1.  `@pnp/sp/lists` is not included in the FileExplorerService.ts, but used (see the linked issue)
The result that web.lists is undefined and that exception. Used here: https://github.com/pnp/sp-dev-fx-controls-react/blob/dda0256dab865a47c56a971763bf44f18689a5dc/src/services/FolderExplorerService.ts#L44

2. double encoding of folder paths (of the "%" symbol) in the same service. This causes the list of folders to be always empty even after the change above (see the linked issue). The pnpjs library already does encoding of this parameter. pre-encoding it results in double-encoding of the "%" symbol and invalid folder paths.
