### PR TITLE
Fix docs for new file picker custom renderers ("|" not escaped)

### DIFF
--- a/docs/documentation/docs/controls/FilePicker.md
+++ b/docs/documentation/docs/controls/FilePicker.md
@@ -76,8 +76,8 @@ The FilePicker component can be configured with the following properties:
 | hideLocalUploadTab | boolean | no | Specifies if LocalUploadTab should be hidden. |
 | hideLinkUploadTab | boolean | no | Specifies if LinkUploadTab should be hidden. |
 | storeLastActiveTab | boolean | no | Specifies if last active tab will be stored after the Upload panel has been closed. Note: the value of selected tab is stored in the queryString hash. Default `true` |
-| renderCustomUploadTabContent | (filePickerResult: IFilePickerResult) => JSX.Element | null | no | Optional renderer to add custom user-defined fields to "Upload" tab |
-| renderCustomLinkTabContent | (filePickerResult: IFilePickerResult) => JSX.Element | null | no | Optional renderer to add custom user-defined fields to "Link" tab |
+| renderCustomUploadTabContent | (filePickerResult: IFilePickerResult) => JSX.Element \| null | no | Optional renderer to add custom user-defined fields to "Upload" tab |
+| renderCustomLinkTabContent | (filePickerResult: IFilePickerResult) => JSX.Element \| null | no | Optional renderer to add custom user-defined fields to "Link" tab |
 
 interface `IFilePickerResult`
 


### PR DESCRIPTION
…ption)

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | documentation for #746

#### What's in this Pull Request?

The documentation fix (descriptions for the added `renderCustomUploadTabContent ` and `renderCustomLinkTabContent ` are broken). Vertical line was not escaped.
