### PR TITLE
Fix duplicate when higher sub Term is selected "selectChildrenIfParentSelected".

### DIFF
--- a/src/controls/taxonomyPicker/TaxonomyPicker.tsx
+++ b/src/controls/taxonomyPicker/TaxonomyPicker.tsx
@@ -283,14 +283,16 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
       }
 
       if (children.length) {
-        activeNodes.push(...children.map(c => {
-          return {
-            name: c.Name,
-            key: c.Id,
-            path: c.PathOfTerm,
-            termSet: c.TermSet.Id
-          };
-        }));
+        [...children].map(c => {
+          if (activeNodes.find(item => item.key == c.Id) === undefined) {
+            activeNodes.push({
+              name: c.Name,
+              key: c.Id,
+              path: c.PathOfTerm,
+              termSet: c.TermSet.Id
+            });
+          }
+        });
       }
     } else {
       // Remove the term from the list of active nodes


### PR DESCRIPTION
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | partially #765, mentioned in #765 

#### What's in this Pull Request?
I use the property "selectChildrenIfParentSelected" to test the new functionality and think to found a issue when selecting terms on following sequence.
If selected Term(for the example Switzerland), selects all sub terms associated what is expected, but if select "countries" the terms are added twice, plus "countries".
This code fix validate existing and don't include twice.

![image](https://user-images.githubusercontent.com/8522348/103181086-459e4e00-489d-11eb-8954-21318000ad28.png)

![image](https://user-images.githubusercontent.com/8522348/103181078-34edd800-489d-11eb-8124-227c6f6806ac.png)
