### PR TITLE
PeoplePicker - Display user title if user is not found or inactive

### DIFF
--- a/docs/documentation/docs/controls/PeoplePicker.md
+++ b/docs/documentation/docs/controls/PeoplePicker.md
@@ -70,7 +70,8 @@ The People picker control can be configured with the following properties:
 | onChange | (items: IPersonaProps[]) => void | no | Get the selected users in the control. | |
 | peoplePickerWPclassName | string | no | applies custom styling to the people picker element | |
 | peoplePickerCntrlclassName | string | no | applies custom styling to the people picker control only | |
-| defaultSelectedUsers | string[] | no | Default selected user emails or login names or user title`|inactive`. User title is just to display the inactive users. Append the user title with string `|inactive` in lower case. | |
+| defaultSelectedUsers | string[] | no | Default selected user emails or login names, optionally append `/title` with forward slash.
+If user is not found then only optional title will be shown. If you do not have email or login name of inactive users just pass `/title` alone prefixed with slash.| |
 | webAbsoluteUrl | string | no | Specify the site URL on which you want to perform the user query call. If not provided, the people picker will perform a tenant wide people/group search. When provided it will search users/groups on the provided site. | |
 | principalTypes | PrincipalType[] | no | Define which type of data you want to retrieve: User, SharePoint groups, Security groups. Multiple are possible. | |
 | ensureUser | boolean | no | When ensure user property is true, it will return the local user ID on the current site when doing a tenant wide search. | false |

--- a/docs/documentation/docs/controls/PeoplePicker.md
+++ b/docs/documentation/docs/controls/PeoplePicker.md
@@ -70,7 +70,7 @@ The People picker control can be configured with the following properties:
 | onChange | (items: IPersonaProps[]) => void | no | Get the selected users in the control. | |
 | peoplePickerWPclassName | string | no | applies custom styling to the people picker element | |
 | peoplePickerCntrlclassName | string | no | applies custom styling to the people picker control only | |
-| defaultSelectedUsers | string[] | no | Default selected user emails or login names | |
+| defaultSelectedUsers | string[] | no | Default selected user emails or login names or user title`|inactive`. User title is just to display the inactive users. Append the user title with string `|inactive` in lower case. | |
 | webAbsoluteUrl | string | no | Specify the site URL on which you want to perform the user query call. If not provided, the people picker will perform a tenant wide people/group search. When provided it will search users/groups on the provided site. | |
 | principalTypes | PrincipalType[] | no | Define which type of data you want to retrieve: User, SharePoint groups, Security groups. Multiple are possible. | |
 | ensureUser | boolean | no | When ensure user property is true, it will return the local user ID on the current site when doing a tenant wide search. | false |

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -93,7 +93,7 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
     if (defaultSelectedUsers) {
       let selectedPersons: IPersonaProps[] = [];
       for (const userValue of props.defaultSelectedUsers) {
-        if (userValue.endsWith("|inactive")) {
+        if (userValue && userValue.endsWith("|inactive")) {
           const temp: string = userValue.slice(0, -9);
           if (temp) {
             const inactiveUser: IPersonaProps = { text: temp };

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -93,18 +93,17 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
     if (defaultSelectedUsers) {
       let selectedPersons: IPersonaProps[] = [];
       for (const userValue of props.defaultSelectedUsers) {
-        if (userValue && userValue.endsWith("|inactive")) {
-          const temp: string = userValue.slice(0, -9);
-          if (temp) {
-            const inactiveUser: IPersonaProps = { text: temp };
-            selectedPersons.push(inactiveUser);
-          }
+        let valueAndTitle: string[] = [];
+        valueAndTitle.push(userValue);
+        if (userValue && userValue.indexOf('/') > -1)
+          valueAndTitle = userValue.split('/');
+        const userResult = await this.peopleSearchService.searchPersonByEmailOrLogin(valueAndTitle[0], principalTypes, webAbsoluteUrl, this.groupId, ensureUser);
+        if (userResult) {
+          selectedPersons.push(userResult);
         }
-        else {
-          const userResult = await this.peopleSearchService.searchPersonByEmailOrLogin(userValue, principalTypes, webAbsoluteUrl, this.groupId, ensureUser);
-          if (userResult) {
-            selectedPersons.push(userResult);
-          }
+        else if (valueAndTitle.length == 2 && valueAndTitle[1]) { //user not found.. bind the title if exists
+          const inactiveUser: IPersonaProps = { text: valueAndTitle[1] };
+          selectedPersons.push(inactiveUser);
         }
       }
 

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -93,9 +93,18 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
     if (defaultSelectedUsers) {
       let selectedPersons: IPersonaProps[] = [];
       for (const userValue of props.defaultSelectedUsers) {
-        const userResult = await this.peopleSearchService.searchPersonByEmailOrLogin(userValue, principalTypes, webAbsoluteUrl, this.groupId, ensureUser);
-        if (userResult) {
-          selectedPersons.push(userResult);
+        if (userValue.endsWith("|inactive")) {
+          const temp: string = userValue.slice(0, -9);
+          if (temp) {
+            const inactiveUser: IPersonaProps = { text: temp };
+            selectedPersons.push(inactiveUser);
+          }
+        }
+        else {
+          const userResult = await this.peopleSearchService.searchPersonByEmailOrLogin(userValue, principalTypes, webAbsoluteUrl, this.groupId, ensureUser);
+          if (userResult) {
+            selectedPersons.push(userResult);
+          }
         }
       }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | fixes #768 , partially #Y, mentioned in #Z

#### What's in this Pull Request?

To display user title if user is not found or inactive.

