### PR TITLE
ListView: Filter functions from props when checking equality

### DIFF
--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -111,7 +111,7 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
    */
   public componentDidUpdate(prevProps: IListViewProps, prevState: IListViewState): void {
 
-    if (!isEqual(prevProps, this.props)) {
+    if (!isEqual(this._filterFunctions(prevProps), this._filterFunctions(this.props))) {
       // select default items
       this._setSelectedItems();
       // Reset the selected items
@@ -548,6 +548,16 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
     }
 
     return result;
+  }
+
+  private _filterRenderFunction(f: IViewField) {
+    const { render, ...fields } = f;
+    return fields;
+  }
+
+  private _filterFunctions(p: IListViewProps) {
+    const { selection: s, viewFields: v, ...otherProps } = p;
+    return { ...otherProps, viewFields: (v || []).map(this._filterRenderFunction) };
   }
 
   /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #251

#### What's in this Pull Request?

This fixes the issue with #251 by filtering known functions from isEqual comparison. It might create new issues when selection or render function changes, but comparing functions for equality is a near impossible job.