### PR TITLE
Fix case sensitive fluent icon search service

### DIFF
--- a/src/services/FluentIconsService.ts
+++ b/src/services/FluentIconsService.ts
@@ -20,7 +20,7 @@ export class FluentIconsService {
 
   public search = (query: string, startsWith?: boolean): string[] => {
     const lowerCasedQuery = query.toLowerCase();
-    return this._iconNames.filter(name => startsWith === false ? name.toLowerCase().indexOf(lowerCasedQuery) !== -1 : name.toLowerCase().indexOf(query) === 0);
+    return this._iconNames.filter(name => !startsWith ? name.toLowerCase().indexOf(lowerCasedQuery) !== -1 : name.toLowerCase().indexOf(lowerCasedQuery) === 0);
   }
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | Nothing logged I could find

#### What's in this Pull Request?

There is an issue in the Icon Picker control where searching for Fluent icon names is case sensitive. For example, searching for "aadlogo" will return an icon, whereas searching for "AADLogo", which is the friendly name of the icon, returns nothing.

Searching for "aadlogo"

![image](https://user-images.githubusercontent.com/985283/109926898-59d54180-7c78-11eb-9f64-864bab285842.png)

Searching for "AADLogo"

![image](https://user-images.githubusercontent.com/985283/109926939-66599a00-7c78-11eb-8266-393a936e5cbe.png)

This fix ensures that the casing of the search term is ignored so that icons are returned regardless of lower/uppercase characters.

Thanks!
