### PR TITLE
Fix broken link : AccessibleAccordion

### DIFF
--- a/docs/documentation/docs/index.md
+++ b/docs/documentation/docs/index.md
@@ -52,7 +52,7 @@ telemetry.optOut();
 
 The following controls are currently available:
 
-- [AccessibleAccordion](./controls/AccessibleAccordion/Accordion) (Control to render an accordion. React `AccessibleAccourdion`-based implementation)
+- [AccessibleAccordion](./controls/accessibleAccordion/Accordion) (Control to render an accordion. React `AccessibleAccourdion`-based implementation)
 - [Accordion](./controls/Accordion) (Control to render an accordion)
 - [Carousel](./controls/Carousel) (Control displays children elements with 'previous/next element' options)
 - [Charts](./controls/ChartControl) (makes it easy to integrate [Chart.js](https://www.chartjs.org/) charts into web part)

--- a/docs/documentation/mkdocs.yml
+++ b/docs/documentation/mkdocs.yml
@@ -9,7 +9,7 @@ nav:
     - 'Submitting a PR': 'guides/submitting-pr.md'
     - 'Migrate v1 to v2': 'guides/migrate-from-v1.md'
   - Controls:
-    - AccessibleAccordion: 'controls/AccessibleAccordion/Accordion.md'
+    - AccessibleAccordion: 'controls/accessibleAccordion/Accordion.md'
     - Accordion: 'controls/Accordion.md'
     - Carousel: 'controls/Carousel.md'
     - Charts:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues  | fixes #818

#### What's in this Pull Request?

1. The link to the "AccessibleAccordion" control page is broken in the documentation site : https://pnp.github.io/sp-dev-fx-controls-react/#available-controls

2. The "Controls" navigation node on the documentation site is broken https://pnp.github.io/sp-dev-fx-controls-react/controls
