### PR TITLE
[Treeview] Fix two potential null reference issues

### DIFF
--- a/src/controls/treeView/TreeView.tsx
+++ b/src/controls/treeView/TreeView.tsx
@@ -31,7 +31,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
     this.handleTreeExpandCollapse = this.handleTreeExpandCollapse.bind(this);
     this.handleOnSelect = this.handleOnSelect.bind(this);
 
-    if (props.expandToSelected) {
+    if (props.expandToSelected && props.defaultSelectedKeys) {
       props.defaultSelectedKeys.forEach(element => {
         this.pathTo(props.items, element);
       });
@@ -41,19 +41,21 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
 
   private pathTo = (array: ITreeItem[], target: string): string => {
     let result: string;
-    array.some(({ key, children = [] }) => {
-      if (key === target) {
-        this.nodesToExpand.push(key);
-        result = key;
-        return true;
-      }
-      let temp = this.pathTo(children, target);
-      if (temp) {
-        this.nodesToExpand.push(key);
-        result = key + '.' + temp;
-        return true;
-      }
-    });
+    if (array) {
+      array.some(({ key, children = [] }) => {
+        if (key === target) {
+          this.nodesToExpand.push(key);
+          result = key;
+          return true;
+        }
+        let temp = this.pathTo(children, target);
+        if (temp) {
+          this.nodesToExpand.push(key);
+          result = key + '.' + temp;
+          return true;
+        }
+      });
+    }
     return result;
   }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]

#### What's in this Pull Request?
A fix for two potential null reference issues:
- when `expandToSelected == true` but `defaultSelectedKeys == null`. This combination of properties does not make much sense : if you want  `expandToSelected` you NEED values in defaultSelectedKeys, but `defaultSelectedKeys` is not required thus this combination can happen and it breaks the control.
- when `expandToSelected == true` but somewhere in the tree there is a `treeItem.children == null`. You should set `children == null` when you don't want the expand arrow to show, but it breaks in combination with `expandToSelection == true`.

This PR fixes both issues.