### PR TITLE
Bug/804

### DIFF
--- a/src/controls/treeView/TreeItem.tsx
+++ b/src/controls/treeView/TreeItem.tsx
@@ -106,7 +106,7 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
     let active = props.activeItems.filter(item => item.key === props.treeItem.key);
 
     let expanded = props.defaultExpanded;
-    if (props.nodesToExpand.indexOf(props.treeItem.key) != -1) {
+    if (props.nodesToExpand.indexOf(props.treeItem.key) != -1 && props.treeItem.children.some(child => this.props.nodesToExpand.indexOf(child.key) > -1)) {
       expanded = true;
     }
 
@@ -211,7 +211,7 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
   /**
    * Process the child nodes
    */
-  public createChildNodes = (list, paddingLeft) => {
+  public createChildNodes = (list: ITreeItem[], paddingLeft: number) => {
     if (list.length) {
       const {
         treeItem,

--- a/src/controls/treeView/TreeItem.tsx
+++ b/src/controls/treeView/TreeItem.tsx
@@ -106,7 +106,7 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
     let active = props.activeItems.filter(item => item.key === props.treeItem.key);
 
     let expanded = props.defaultExpanded;
-    if (props.nodesToExpand.indexOf(props.treeItem.key) != -1 && props.treeItem.children.some(child => this.props.nodesToExpand.indexOf(child.key) > -1)) {
+    if (props.nodesToExpand.indexOf(props.treeItem.key) != -1) {
       expanded = true;
     }
 

--- a/src/controls/treeView/TreeView.tsx
+++ b/src/controls/treeView/TreeView.tsx
@@ -44,7 +44,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
     if (array) {
       array.some(({ key, children = [] }) => {
         if (key === target) {
-          this.nodesToExpand.push(key);
+          // this.nodesToExpand.push(key);
           result = key;
           return true;
         }

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -412,7 +412,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
       canMoveNext: true,
       currentCarouselElement: this.carouselElements[0],
       comboBoxListItemPickerListId: '0ffa51d7-4ad1-4f04-8cfe-98209905d6da',
-      treeViewSelectedKeys: ['gc1', 'gc3'],
+      treeViewSelectedKeys: ['3', 'gc3'],
       showAnimatedDialog: false,
       showCustomisedAnimatedDialog: false,
       showSuccessDialog: false,
@@ -1579,8 +1579,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             defaultSelectedKeys={this.state.treeViewSelectedKeys}
             onExpandCollapse={this.onExpandCollapseTree}
             onSelect={this.onItemSelected}
-            defaultExpandedChildren={true}
-          //expandToSelected={true}
+            defaultExpandedChildren={false}
+            expandToSelected={true}
           // onRenderItem={this.renderCustomTreeItem}
           />
           <PrimaryButton onClick={() => { this.setState({ treeViewSelectedKeys: [] }); }}>Clear selection</PrimaryButton>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| Related issues?  | fixes #804 

#### What's in this Pull Request?

Fix to prevent TreeView from expanding a selected node by default when expandToSelected is set to true

