### PR TITLE
[V2] Fix default item selection in TreeView

### DIFF
--- a/docs/documentation/docs/controls/TreeView.md
+++ b/docs/documentation/docs/controls/TreeView.md
@@ -34,7 +34,7 @@ import { TreeView, ITreeItem, TreeViewSelectionMode } from "@pnp/spfx-controls-r
     items={treeitems}
     defaultExpanded={false}
     selectionMode={TreeViewSelectionMode.Multiple}
-    selectChildrenIfParentSelected={true}
+    selectChildrenMode={SelectChildrenMode.Select | SelectChildrenMode.Unselect}
     showCheckboxes={true}
     treeItemActionsDisplayMode={TreeItemActionsDisplayMode.ContextualMenu}
     defaultSelectedKeys={['key1', 'key2']}
@@ -91,7 +91,8 @@ The `TreeView` control can be configured with the following properties:
 | items                          | ITreeItem[]                | yes      | An array of tree items to display. refer [example](#example-of-array-of-tree-items-used-to-render-control-as-in-first-screenshot). |
 | defaultExpanded                | boolean                    | no       | Specify if the tree items are displayed as expanded by default (defaults to false.                                                |
 | selectionMode                  | enum                       | no       | Specifies the selection mode of tree view (defaults to Single selection).                                                            |
-| selectChildrenIfParentSelected | boolean                    | no       | Specifies if the childrens should be selected when parent item is selected (defaults to false).                                      |
+| selectChildrenIfParentSelected | boolean                    | no       | Specifies if the children should be selected when parent item is selected (defaults to false). __Deprecated__: prefer usage of `selectChildrenMode` for more flexibility.                                      |
+| selectChildrenMode | SelectChildrenMode                    | no       | Specifies if the children should be selected when parent item is selected (defaults to None). Flagged enum, values can be combined eg. `SelectChildrenMode.Select \| SelectChildrenMode.Unselect`                                     |
 | showCheckboxes                 | boolean                    | yes      | Specify if the checkboxes should be displayed for selection.                                                                       |
 | treeItemActionsDisplayMode     | TreeItemActionsDisplayMode | no       | Specifies the display mode of the tree item actions.                                                                                 |
 | defaultSelectedKeys            | string[]                   | no       | Specifies keys of items to be selected by default.                                                                                   |
@@ -110,6 +111,19 @@ Specifies the selection mode of tree item.
 | Single   |
 | Multiple |
 | None     |
+
+Enum `SelectChildrenMode`
+
+Specifies when the children of a selected item need to be automatically selected.
+
+| Value    | Description                                                      |
+|----------|------------------------------------------------------------------|
+| None   | Children are never selected                                        |
+| Select | When selecting an item, its children are also selected             |
+| Unselect     | When unselecting an item, its children are also unselected   |
+| Mount     | When the component is mounted, all children of selected items are also selected |
+| Update     | When the component receives new props, all children of selected items are also selected |
+| All     | Shorthand for a combination of all of the above, same as `SelectChildrenMode.Select \| SelectChildrenMode.Unselect \| SelectChildrenMode.Mount \| SelectChildrenMode.Update` |                    |
 
 Interface `ITreeItem`
 

--- a/src/controls/treeView/ITreeViewProps.ts
+++ b/src/controls/treeView/ITreeViewProps.ts
@@ -38,7 +38,7 @@ export interface ITreeViewProps {
    */
   selectionMode?: TreeViewSelectionMode;
   /**
-   * @deprecated Use selectChildrenMode instead
+   * @deprecated Use selectChildrenMode instead.
    * Specifies if the childrens should be selected when parent is selected.
    * By default this is set to false.
    */

--- a/src/controls/treeView/ITreeViewProps.ts
+++ b/src/controls/treeView/ITreeViewProps.ts
@@ -10,6 +10,15 @@ export enum TreeViewSelectionMode {
   None = 2
 }
 
+export enum SelectChildrenMode {
+  None = 0,
+  Select = 1 << 0, // 0001
+  Unselect = 1 << 1,     // 0010
+  Mount = 1 << 2,    // 0100
+  Update = 1 << 3,   // 1000
+  All = ~(~0 << 4)   // 1111
+}
+
 /**
  * TreeView properties interface
  */
@@ -29,10 +38,16 @@ export interface ITreeViewProps {
    */
   selectionMode?: TreeViewSelectionMode;
   /**
+   * @deprecated Use selectChildrenMode instead
    * Specifies if the childrens should be selected when parent is selected.
    * By default this is set to false.
    */
   selectChildrenIfParentSelected?: boolean;
+    /**
+   * Specifies if the childrens should be selected when parent is selected. Flagged enum, so values can be combined eg. SelectChildrenMode.Select | SelectChildrenMode.Unselect
+   * By default this is set to None.
+   */
+  selectChildrenMode?: SelectChildrenMode;
   /**
   * Specifies if the checkboxes should be displayed for selection.
   */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]

#### What's in this Pull Request?

Fixes the selection of children when passed in as `defaultSelectedKeys`. Before, when a parent matched a key the children weren't checked any more if they were also part of `defaultSelectedKeys`. As a result, only the parent showed as selected. This is now fixed.

Deprecated `selectChildrenIfParentSelected` and added `selectChildrenMode`. This is a flagged enum which allows much more flexibility on when this before should be triggered. Currently, the behavior is triggered on mount, update (when new props are passed), select and unselect. As a result, you can never pass in the key of a parent and just one of its children as all of the children will be selected. With the change to a flagged enum, you can control all 4 lifetime moments separately.

Old behavior can be replicated with `SelectChildrenMode.None` and `SelectChildrenMode.All`. For more granular control can also be set to eg. `SelectChildrenMode.Select | SelectChildrenMode.Unselect`, which means that children will be selected/unselected when the parent is selected or unselected but not when the control mounts OR when the props are updated.