### PR TITLE
Fix #799 React error in FileBrowser paging

### DIFF
--- a/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
+++ b/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
@@ -185,7 +185,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                         selectionPreservedOnEmptyClick={true}
                         enterModalSelectionOnTouch={true}
                         onRenderRow={this._onRenderRow}
-                        onRenderMissingItem={this._loadNextDataRequest}
+                        onRenderMissingItem={() => { this._loadNextDataRequest(); return null; }}
                       />) :
                       (<TilesList
                         fileBrowserService={this.props.fileBrowserService}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #826 

#### What's in this Pull Request?

In the file picker control, the site file picker tab uses a `<DetailList>` for file selection. If a list of files is too long and requires pagination, it calls this `onRenderMissingItem` callback. This function is asyncronous and returns a promise, but this causes a React render error because `onRenderMissingItem` is expecting to render something.

Instead, we call the asyncronous function and return null.