### PR TITLE
Fix invalid CSS for file picker

### DIFF
--- a/src/controls/filePicker/FilePicker.module.scss
+++ b/src/controls/filePicker/FilePicker.module.scss
@@ -176,7 +176,7 @@
 }
 .scrollablePaneWrapper {
   height: 75vh;
-  position: 'relative';
+  position: relative;
   overflow: hidden;
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Small bugfix: invalid value for the "relative" in file picker CSS (unnecessary apostrophes) - error in chrome.
To observe the bug, try putting a webpart that uses the file picker inside an IFRAME for example (sidebar layout broken)