### PR TITLE
Add support for a defaultFolderPath prop for the <FilePicker/>

### DIFF
--- a/docs/documentation/docs/controls/FilePicker.md
+++ b/docs/documentation/docs/controls/FilePicker.md
@@ -75,7 +75,8 @@ The FilePicker component can be configured with the following properties:
 | label | string | no | Specifies the text describing the file picker. |
 | buttonLabel | string | no | Specifies the label of the file picker button. |
 | buttonIcon | string | no | In case it is provided the file picker will be rendered as an action button. |
-  buttonIconProps | IIconProps | no | In case it is provided the file picker will be rendered as an Icon the and all can define Properties for Icon  |
+| buttonIconProps | IIconProps | no | In case it is provided the file picker will be rendered as an Icon the and all can define Properties for Icon  |
+| defaultFolderAbsolutePath | string | no | Optional string parameter to set a default active folder/library for the SiteFilesTab. E.g. `"https://contoso.sharepoint.com/teams/siteName/documentLibrary/Folder 1/SubFolder 1"`  |
 | onSave | (filePickerResult: IFilePickerResult[]) => void | yes | Handler when the file has been selected and picker has been closed. |
 | onChange | (filePickerResult: IFilePickerResult[]) => void | no | Handler when the file selection has been changed. |
 | onCancel | () => void | no | Handler when file picker has been cancelled. |

--- a/src/controls/filePicker/FilePicker.tsx
+++ b/src/controls/filePicker/FilePicker.tsx
@@ -212,6 +212,7 @@ export class FilePicker extends React.Component<
               <SiteFilePickerTab
                 fileBrowserService={this.fileBrowserService}
                 includePageLibraries={this.props.includePageLibraries}
+                defaultFolderAbsolutePath={this.props.defaultFolderAbsolutePath}
                 {...linkTabProps}
               />
             )}

--- a/src/controls/filePicker/FilePicker.types.ts
+++ b/src/controls/filePicker/FilePicker.types.ts
@@ -1,10 +1,10 @@
 import { BaseComponentContext } from '@microsoft/sp-component-base';
 import { IBreadcrumbItem } from "office-ui-fabric-react/lib/Breadcrumb";
-import { IFile, ILibrary } from "../../services/FileBrowserService.types";
+import { IFile, IFolder, ILibrary } from "../../services/FileBrowserService.types";
 
 export interface FilePickerBreadcrumbItem extends IBreadcrumbItem {
   libraryData?: ILibrary;
-  folderData?: IFile;
+  folderData?: IFolder;
 }
 
 export interface IFilePickerTab {

--- a/src/controls/filePicker/IFilePickerProps.ts
+++ b/src/controls/filePicker/IFilePickerProps.ts
@@ -156,4 +156,9 @@ export interface IFilePickerProps {
    * Specifies if Site Pages library to be visible on Sites tab
    */
   includePageLibraries?: boolean;
+
+  /**
+   * Specifies a default folder to be active in the Site Files tab
+   */
+  defaultFolderAbsolutePath?: string;
 }

--- a/src/controls/filePicker/SiteFilePickerTab/ISiteFilePickerTabProps.ts
+++ b/src/controls/filePicker/SiteFilePickerTab/ISiteFilePickerTabProps.ts
@@ -10,5 +10,10 @@ export interface ISiteFilePickerTabProps extends IFilePickerTab {
    */
   breadcrumbFirstNode?: IBreadcrumbItem;
 
+  /**
+   * Specifies a default folder to be active in the Site Files tab
+   */
+  defaultFolderAbsolutePath?: string;
+
   includePageLibraries?: boolean;
 }

--- a/src/services/FileBrowserService.ts
+++ b/src/services/FileBrowserService.ts
@@ -80,6 +80,30 @@ export class FileBrowserService {
   }
 
   /**
+   * Gets document and media libraries from the site
+   */
+  public getLibraryNameByInternalName = async (internalName: string): Promise<string> => {
+    try {
+      const absoluteUrl = this.context.pageContext.web.absoluteUrl;
+      const restApi = `${absoluteUrl}/_api/web/GetFolderByServerRelativeUrl('${internalName}')/Properties?$select=vti_x005f_listtitle`;
+      const libraryResult = await this.context.spHttpClient.get(restApi, SPHttpClient.configurations.v1);
+
+      if (!libraryResult || !libraryResult.ok) {
+        throw new Error(`Something went wrong when executing request. Status='${libraryResult.status}'`);
+      }
+      const libResults: { vti_x005f_listtitle: string } = await libraryResult.json();
+      if (!libResults || !libResults.vti_x005f_listtitle) {
+        throw new Error(`Cannot read data from the results.`);
+      }
+
+      return libResults.vti_x005f_listtitle != internalName && libResults.vti_x005f_listtitle || "";
+    } catch (error) {
+      console.error(`[FileBrowserService.getSiteLibraryNameByInternalName]: Err='${error.message}'`);
+      return null;
+    }
+  }
+
+  /**
    * Downloads document content from SP location.
    */
   public downloadSPFileContent = async (absoluteFileUrl: string, fileName: string): Promise<File> => {
@@ -117,7 +141,7 @@ export class FileBrowserService {
         }
       };
       if (folderPath) {
-          body.parameters["FolderServerRelativeUrl"] = folderPath;
+        body.parameters["FolderServerRelativeUrl"] = folderPath;
       }
       const data: any = await this.context.spHttpClient.fetch(restApi, SPHttpClient.configurations.v1, {
         method: "POST",

--- a/src/services/FileBrowserService.types.ts
+++ b/src/services/FileBrowserService.types.ts
@@ -26,6 +26,10 @@ export interface IFile {
   supportsThumbnail: boolean;
 }
 
+export interface IFolder extends Pick<IFile, "name" | "absoluteUrl" | "serverRelativeUrl"> {
+
+}
+
 export interface ILibrary {
   title: string;
   absoluteUrl: string;

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -172,11 +172,12 @@ import {
 import { MyTeams } from "../../../controls/MyTeams";
 import { TeamPicker } from "../../../TeamPicker";
 import { TeamChannelPicker } from "../../../TeamChannelPicker";
-import {​​ DragDropFiles }​​ from "../../../DragDropFiles";
-import {​​ SitePicker }​​ from "../../../controls/sitePicker/SitePicker";
+import { DragDropFiles } from "../../../DragDropFiles";
+import { SitePicker } from "../../../controls/sitePicker/SitePicker";
 import { DynamicForm } from '../../../controls/dynamicForm';
 import { LocationPicker } from "../../../controls/locationPicker/LocationPicker";
 import { ILocationPickerItem } from "../../../controls/locationPicker/ILocationPicker";
+import { debounce } from "lodash";
 
 
 
@@ -854,7 +855,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             <Link href="https://pnp.github.io/sp-dev-fx-controls-react/">See all</Link>
           } />
 
-<Stack styles={{ root: { marginBottom: 200 } }}>
+        <Stack styles={{ root: { marginBottom: 200 } }}>
           <MyTeams
             title="My Teams"
             webPartContext={this.props.context}
@@ -1274,12 +1275,12 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           iconName="Upload"
           labelMessage="My custom upload File"
         >
-        <Placeholder iconName='BulkUpload'
-          iconText='Drag files or folder with files here...'
-          description={defaultClassNames => <span className={defaultClassNames}>Drag files or folder with files here...</span>}
-          buttonLabel='Configure'
-          hideButton={this.props.displayMode === DisplayMode.Read}
-          onConfigure={this._onConfigure} />
+          <Placeholder iconName='BulkUpload'
+            iconText='Drag files or folder with files here...'
+            description={defaultClassNames => <span className={defaultClassNames}>Drag files or folder with files here...</span>}
+            buttonLabel='Configure'
+            hideButton={this.props.displayMode === DisplayMode.Read}
+            onConfigure={this._onConfigure} />
         </DragDropFiles>
         <br></br>
 
@@ -1387,14 +1388,14 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
               <div className="ms-font-m">Site picker tester:
               <SitePicker
-                context={this.props.context}
-                label={'select sites'}
-                mode={'site'}
-                allowSearch={true}
-                multiSelect={false}
-                onChange={(sites) => { console.log(sites); }}
-                placeholder={'Select sites'}
-                searchPlaceholder={'Filter sites'} />
+                  context={this.props.context}
+                  label={'select sites'}
+                  mode={'site'}
+                  allowSearch={true}
+                  multiSelect={false}
+                  onChange={(sites) => { console.log(sites); }}
+                  placeholder={'Select sites'}
+                  searchPlaceholder={'Filter sites'} />
               </div>
 
               <div className="ms-font-m">List picker tester:
@@ -1596,11 +1597,16 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
         <div>
           <h3>File Picker</h3>
+          <TextField
+            label="Default SiteFileTab Folder"
+            onChange={debounce((ev, newVal) => { this.setState({ filePickerDefaultFolderAbsolutePath: newVal }); }, 500)}
+            styles={{ root: { marginBottom: 10 } }}
+          />
           <FilePicker
             bingAPIKey="<BING API KEY>"
+            defaultFolderAbsolutePath={this.state.filePickerDefaultFolderAbsolutePath}
             //accepts={[".gif", ".jpg", ".jpeg", ".bmp", ".dib", ".tif", ".tiff", ".ico", ".png", ".jxr", ".svg"]}
             buttonLabel="Add File"
-
             buttonIconProps={{ iconName: 'Add', styles: { root: { fontSize: 42 } } }}
             onSave={this._onFilePickerSave}
             onChange={(filePickerResult: IFilePickerResult[]) => { console.log(filePickerResult); }}

--- a/src/webparts/controlsTest/components/IControlsTestProps.ts
+++ b/src/webparts/controlsTest/components/IControlsTestProps.ts
@@ -42,5 +42,5 @@ export interface IControlsTestState {
   showErrorDialog?: boolean;
   selectedTeam:ITag[];
   selectedTeamChannels:ITag[];
-
+  filePickerDefaultFolderAbsolutePath?: string;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | [ x ]
| Related issues?  | fixes #936 

#### What's in this Pull Request?

Added a property (`defaultFolderAbsolutePath`) to the `<FilePicker/>` to set a default selected library/folder for the `<SiteFilePickerTab/>`.