### PR TITLE
Added onNewTerm called when enter is pressed

### DIFF
--- a/docs/documentation/docs/controls/TaxonomyPicker.md
+++ b/docs/documentation/docs/controls/TaxonomyPicker.md
@@ -51,6 +51,21 @@ private onTaxPickerChange(terms : IPickerTerms) {
 }
 ```
 
+- With the `onNewTerm` property you can capture the event, when text is in the input field and
+enter/return as pressed. With a controlled TaxonomyPicker, this enables you to create the term 
+and have the same flow as in SharePoint Keywords fields.
+
+```typescript
+    const onNewTerm = (value: IPickerTerm): void => {
+            if(value?.name && EmptyGuid === value.key ){
+                console.log(`TaxonmyPicker.onNewTerm name=${value.name}`, value );
+                // Create keyword
+            } else {
+                console.error(`TaxonmyPicker.onNewTerm name=${value?.name}`, value );
+            }
+        };
+```
+
 ## Term actions
 
 Since version `1.12.0`, you can apply term actions to all terms or specific ones. Term actions could for instance be used to retrieve the labels of the term, or retrieve other information. These term actions can be implemented as follows:
@@ -158,6 +173,7 @@ The TaxonomyPicker control can be configured with the following properties:
 | allowMultipleSelections | boolean | no | Defines if the user can select only one or many term sets. Default value is false. |
 | termsetNameOrID | string | yes | The name or Id of your TermSet that you would like the Taxonomy Picker to chose terms from. |
 | onChange | function | no |  captures the event of when the terms in the picker has changed. |
+| onNewTerm | function | no | captures the event when text is in the input field and the user presses return |
 | isTermSetSelectable | boolean | no | Specify if the TermSet itself is selectable in the tree view. |
 | disabledTermIds | string[] | no | Specify which terms should be disabled in the term set so that they cannot be selected. |
 | disableChildrenOfDisabledParents | boolean | no | Specify if you want to disable the child terms when their parent is disabled. |

--- a/docs/documentation/docs/controls/TaxonomyPicker.md
+++ b/docs/documentation/docs/controls/TaxonomyPicker.md
@@ -52,7 +52,7 @@ private onTaxPickerChange(terms : IPickerTerms) {
 ```
 
 - With the `onNewTerm` property you can capture the event, when text is in the input field and
-enter/return as pressed. With a controlled TaxonomyPicker, this enables you to create the term 
+enter/return is pressed. With a controlled TaxonomyPicker, this enables you to create the term 
 and have the same flow as in SharePoint Keywords fields.
 
 ```typescript

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -1,4 +1,4 @@
-import { IPickerTerms } from './ITermPicker';
+import { IPickerTerm, IPickerTerms } from './ITermPicker';
 import { ITermSet, ITerm } from '../../services/ISPTermStorePickerService';
 import { ITermActions } from './termActions/ITermsActions';
 import SPTermStorePickerService from '../../services/SPTermStorePickerService';
@@ -103,6 +103,11 @@ export interface ITaxonomyPickerProps  {
    *
    */
   onGetErrorMessage?: (value: IPickerTerms) => string | Promise<string>;
+
+  /**
+   *  Called when text is in the input field and the enter key is pressed.  
+   */
+  onNewTerm?: (value: IPickerTerm) => void;
 
   /**
    * Static error message displayed below the text field. Use onGetErrorMessage to dynamically change the error message displayed (if any) based on the current value. errorMessage and onGetErrorMessage are mutually exclusive (errorMessage takes precedence).


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #966 

Added the ability to react to the `enter`/`return` key being pressed while a new text is in the input field.

This consists of two parts:
- The new eventHandler `onNewTerm` called when text is input field and return is pressed
- `TermPicker.clearDisplayValue` to clear the input field the `onNewTerm` is used
