### PR TITLE
Charts not updating properly when properties are changed

### DIFF
--- a/src/controls/chartControl/ChartControl.tsx
+++ b/src/controls/chartControl/ChartControl.tsx
@@ -284,7 +284,7 @@ export class ChartControl extends React.Component<IChartControlProps, IChartCont
       type,
       plugins,
       useTheme
-    } = this.props;
+    } = props;
 
     // add event handlers -- if they weren't already provided through options
     if (this.props.onClick !== undefined) {


### PR DESCRIPTION
The _initChart function is not initialising the chart options properly. The props passed as a parameter are never used in the function which means that, when the function is being called from ChartControl.componentWillReceiveProps, the control is never updated with the new properties but it will use the old properties instead.

| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.

If you look at the current implementation of the _initChart function the "props" parameter is never used. The function is using the props already in the object instead (this.props). Because this method is being called by the "ChartControl.componentWillReceiveProps" lifecycle method this means that the object will always be out of the date with the latest changes being passed in and will instead have the values of the previous changes. I hope this makes sense.

