### PR TITLE
fix(TaxonomyPicker): errorMessage not cleared when set to empty value

### DIFF
--- a/src/controls/taxonomyPicker/TaxonomyPicker.tsx
+++ b/src/controls/taxonomyPicker/TaxonomyPicker.tsx
@@ -91,7 +91,7 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
       };
     }
 
-    if (nextProps.errorMessage) {
+    if (nextProps.errorMessage !== this.props.errorMessage) {
       if (!newState) {
         newState = {};
       }

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -445,6 +445,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
       showErrorDialog: false,
       selectedTeam: [],
       selectedTeamChannels: [],
+      errorMessage: "This field is required"
 
     };
 
@@ -536,7 +537,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
    */
   private _onTaxPickerChange = (terms: IPickerTerms) => {
     this.setState({
-      initialValues: terms
+      initialValues: terms,
+      errorMessage: terms.length > 0 ? '' : 'This field is required'
     });
     console.log("Terms:", terms);
   }
@@ -1031,6 +1033,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             isTermSetSelectable={false}
             hideDeprecatedTags={true}
             hideTagsNotAvailableForTagging={true}
+            errorMessage={this.state.errorMessage}
             termActions={{
               actions: [{
                 title: "Get term labels",
@@ -1103,7 +1106,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
                 name: "HR",
                 path: "HR",
                 termSet: "b3e9b754-2593-4ae6-abc2-35345402e186"
-              }]
+              }],
+              errorMessage: ""
             });
           }} />
         </div>

--- a/src/webparts/controlsTest/components/IControlsTestProps.ts
+++ b/src/webparts/controlsTest/components/IControlsTestProps.ts
@@ -44,4 +44,5 @@ export interface IControlsTestState {
   selectedTeam:ITag[];
   selectedTeamChannels:ITag[];
   filePickerDefaultFolderAbsolutePath?: string;
+  errorMessage?: string;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #953

#### What's in this Pull Request?

This PR fixes the TaxonomyPicker to remove the errorMessage label when the errorMessage props is cleared (empty string).
Also updated the ControlTest component to reflect that change.

![image](https://user-images.githubusercontent.com/21177585/131572167-97489a90-c9b2-4418-8f9a-50ee1c2ffe3b.png)
![image](https://user-images.githubusercontent.com/21177585/131572192-465a815d-7000-492f-8edb-af7b7feaeeda.png)

