### PR TITLE
Add onCancel callback for IconPicker

### DIFF
--- a/docs/documentation/docs/controls/IconPicker.md
+++ b/docs/documentation/docs/controls/IconPicker.md
@@ -48,6 +48,7 @@ The IconPicker component can be configured with the following properties:
 | ---- | ---- | ---- | ---- |
 | buttonLabel | string | no | Specifies the label of the icon picker button. |
 | onSave | (iconName: string) => void | yes | Handler when the icon has been selected and picker has been closed. |
+| onCancel | () => void | no | Handler when the panel is closed. |
 | onChange | (iconName: string) => void | no | Handler when the icon selection has been changed. |
 | disabled | boolean | no | Specifies if the picker button is disabled |
 | buttonClassName | boolean | no | If provided, additional class name will be added to the picker button |

--- a/src/controls/iconPicker/IIconPickerProps.ts
+++ b/src/controls/iconPicker/IIconPickerProps.ts
@@ -4,6 +4,10 @@ export interface IIconPickerProps {
      */
     onSave(iconName: string): void;
     /**
+     * call-back function when cancel is clicked
+     */
+    onCancel?(): void;
+    /**
      * call-back function when icon has changed
      */
     onChange?(iconName: string): void;

--- a/src/controls/iconPicker/IconPicker.tsx
+++ b/src/controls/iconPicker/IconPicker.tsx
@@ -107,6 +107,9 @@ export class IconPicker extends React.Component<IIconPickerProps, IIconPickerSta
   }
 
   private closePanel = (): void => {
+    if (this.props.onCancel) {
+      this.props.onCancel();
+    }
     this.setState({
       currentIcon: this.props.currentIcon,
       isPanelOpen: false

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -1684,6 +1684,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
         <IconPicker buttonLabel={'Icon'}
           onChange={(iconName: string) => { console.log(iconName); }}
+          onCancel={() => { console.log("Panel closed"); }}
           onSave={(iconName: string) => { console.log(iconName); }} />
 
         <div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | fixes #1043

#### What's in this Pull Request?
When the IconPicker panel is dismissed, if defined, the new onCancel callback is called.


#### Guidance
- *You can delete this section when you are submitting the pull request.* 
- *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
- *Please target your PR to **dev** branch.*
