### PR TITLE
Changed single selection to multiple selection for Recent, OneDrive and Site Files tabs in FilePicker component

### DIFF
--- a/src/controls/filePicker/OneDriveFilesTab/IOneDriveFilesTabState.ts
+++ b/src/controls/filePicker/OneDriveFilesTab/IOneDriveFilesTabState.ts
@@ -2,7 +2,7 @@ import { OneDriveFilesBreadcrumbItem } from "./OneDriveFilesTab.types";
 import { IFilePickerResult } from "../FilePicker.types";
 
 export interface IOneDriveFilesTabState {
-  filePickerResult: IFilePickerResult;
+  filePickerResults: IFilePickerResult[];
   libraryAbsolutePath: string;
   libraryUrl: string;
   folderPath: string;

--- a/src/controls/filePicker/OneDriveFilesTab/OneDriveFilesTab.tsx
+++ b/src/controls/filePicker/OneDriveFilesTab/OneDriveFilesTab.tsx
@@ -18,7 +18,7 @@ export class OneDriveFilesTab extends React.Component<IOneDriveFilesTabProps, IO
     super(props);
 
     this.state = {
-      filePickerResult: null,
+      filePickerResults: [],
       libraryAbsolutePath: undefined,
       libraryUrl: '/Documents',
       folderPath: undefined,
@@ -66,12 +66,12 @@ export class OneDriveFilesTab extends React.Component<IOneDriveFilesTabProps, IO
     return (
       <div className={styles.tabContainer}>
         <div className={styles.tabHeaderContainer}>
-          <Breadcrumb items={this.state.breadcrumbItems} /*onRenderItem={this.renderBreadcrumbItem}*/ className={styles.breadcrumbNav}/>
+          <Breadcrumb items={this.state.breadcrumbItems} /*onRenderItem={this.renderBreadcrumbItem}*/ className={styles.breadcrumbNav} />
         </div>
         <div className={styles.tabFiles}>
           {this.state.libraryAbsolutePath !== undefined &&
             <FileBrowser
-              onChange={(filePickerResult: IFilePickerResult) => this._handleSelectionChange(filePickerResult)}
+              onChange={(filePickerResults: IFilePickerResult[]) => this._handleSelectionChange(filePickerResults)}
               onOpenFolder={(folder: IFile) => this._handleOpenFolder(folder, true)}
               fileBrowserService={this.props.oneDriveService}
               libraryUrl={this.state.libraryUrl}
@@ -81,7 +81,7 @@ export class OneDriveFilesTab extends React.Component<IOneDriveFilesTabProps, IO
         <div className={styles.actionButtonsContainer}>
           <div className={styles.actionButtons}>
             <PrimaryButton
-              disabled={!this.state.filePickerResult}
+              disabled={this.state.filePickerResults && !this.state.filePickerResults.length}
               onClick={() => this._handleSave()} className={styles.actionButton}>{strings.OpenButtonLabel}</PrimaryButton>
             <DefaultButton onClick={() => this._handleClose()} className={styles.actionButton}>{strings.CancelButtonLabel}</DefaultButton>
           </div>
@@ -124,27 +124,26 @@ export class OneDriveFilesTab extends React.Component<IOneDriveFilesTabProps, IO
 
     this.setState({
       breadcrumbItems,
-      filePickerResult: undefined
+      filePickerResults: []
     });
   }
 
   /**
    * Is called when user selects a different file
    */
-  private _handleSelectionChange = (filePickerResult: IFilePickerResult) => {
-    if (filePickerResult) {
+  private _handleSelectionChange = (filePickerResults: IFilePickerResult[]) => {
+    filePickerResults.map((filePickerResult: IFilePickerResult) => {
       filePickerResult.downloadFileContent = () => { return this.props.oneDriveService.downloadSPFileContent(filePickerResult.spItemUrl, filePickerResult.fileName); };
-    }
-    this.setState({
-      filePickerResult
     });
+
+    this.setState({ filePickerResults });
   }
 
   /**
    * Called when user saves
    */
   private _handleSave = () => {
-    this.props.onSave([this.state.filePickerResult]);
+    this.props.onSave(this.state.filePickerResults);
   }
 
   /**

--- a/src/controls/filePicker/RecentFilesTab/IRecentFilesTabState.ts
+++ b/src/controls/filePicker/RecentFilesTab/IRecentFilesTabState.ts
@@ -4,5 +4,5 @@ import { IRecentFile } from "../../../services/FilesSearchService.types";
 export interface IRecentFilesTabState {
   results: IRecentFile[];
   isLoading: boolean;
-  filePickerResult: IFilePickerResult;
+  filePickerResults: IFilePickerResult[];
 }

--- a/src/controls/filePicker/RecentFilesTab/RecentFilesTab.module.scss
+++ b/src/controls/filePicker/RecentFilesTab/RecentFilesTab.module.scss
@@ -131,12 +131,11 @@
   }
 }
 
-.gridListCell.isSelected .itemTileCheckCircle,
-.gridListCell:hover,
-.gridListCell:hover .itemTileCheckCircle {
-  opacity: 1;
+.itemTile.isSelected {
+  .itemTileCheckCircle {
+    opacity: 1;
+  }
 }
-
 .itemTileNamePlate {
   position: absolute;
   bottom:0;

--- a/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
+++ b/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
@@ -235,7 +235,7 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
    * Gets called what a file is selected.
    */
   private _handleItemInvoked = (item: IRecentFile) => {
-    this._selection.setKeySelected(item.key, true, true);
+    this._selection.toggleKeySelected(item.key);
   }
 
   /**

--- a/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
+++ b/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
@@ -45,7 +45,7 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
     this.state = {
       isLoading: true,
       results: [],
-      filePickerResults: null
+      filePickerResults: []
     };
   }
 
@@ -101,7 +101,6 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
     let filePickerResults: IFilePickerResult[] = [];
     // Get the selected item
     this._selection.getSelection().map((selectedKey: IRecentFile) => {
-    this._selection.setKeySelected(selectedKey.key, true, true);
       filePickerResults.push({
         fileAbsoluteUrl: selectedKey.fileUrl,
         fileName: GeneralHelper.getFileNameFromUrl(selectedKey.fileUrl),
@@ -160,7 +159,9 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
   private _renderGridList = (): JSX.Element => {
     return <span className={styles.recentGridList} role="grid">
       <FocusZone>
-        <SelectionZone selection={this._selection} selectionMode={SelectionMode.multiple} onItemInvoked={(item: IRecentFile) => this._handleItemInvoked(item)}>
+        <SelectionZone selection={this._selection}
+          selectionMode={SelectionMode.multiple}
+          onItemInvoked={(item: IRecentFile) => this._handleItemInvoked(item)}>
           <List
             ref={this._linkElement}
             items={this.state.results}

--- a/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
+++ b/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
@@ -39,16 +39,13 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
   constructor(props: IRecentFilesTabProps) {
     super(props);
 
-    this._selection = new Selection({
-      selectionMode: SelectionMode.single,
-      onSelectionChanged: this._onSelectionChanged
-    });
+    this._selection = null;
 
 
     this.state = {
       isLoading: true,
       results: [],
-      filePickerResult: null
+      filePickerResults: null
     };
   }
 
@@ -57,6 +54,10 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
    */
   public async componentDidMount() {
     const recentFilesResult = await this.props.fileSearchService.executeRecentSearch(this.props.accepts);
+    this._selection = new Selection({
+      selectionMode: SelectionMode.multiple,
+      onSelectionChanged: this._onSelectionChanged
+    });
     this._selection.setItems(recentFilesResult, true);
 
     this.setState({
@@ -85,7 +86,7 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
         <div className={styles.actionButtonsContainer}>
           <div className={styles.actionButtons}>
             <PrimaryButton
-              disabled={!this.state.filePickerResult}
+              disabled={this.state.filePickerResults && !this.state.filePickerResults.length}
               onClick={() => this._handleSave()}
               className={styles.actionButton}
             >{strings.OpenButtonLabel}</PrimaryButton>
@@ -97,28 +98,20 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
   }
 
   private _onSelectionChanged = () => {
+    let filePickerResults: IFilePickerResult[] = [];
     // Get the selected item
-    const selectedItems = this._selection.getSelection();
-    if (selectedItems && selectedItems.length > 0) {
-      //Get the selected key
-      const selectedKey: IRecentFile = selectedItems[0] as IRecentFile;
-      const filePickerResult: IFilePickerResult = {
+    this._selection.getSelection().map((selectedKey: IRecentFile) => {
+    this._selection.setKeySelected(selectedKey.key, true, true);
+      filePickerResults.push({
         fileAbsoluteUrl: selectedKey.fileUrl,
         fileName: GeneralHelper.getFileNameFromUrl(selectedKey.fileUrl),
         fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(selectedKey.fileUrl),
         downloadFileContent: () => { return this.props.fileSearchService.downloadSPFileContent(selectedKey.fileUrl, GeneralHelper.getFileNameFromUrl(selectedKey.fileUrl)); }
-      };
+      });
+    });
 
-      // Save the selected file
-      this.setState({
-        filePickerResult
-      });
-    } else {
-      // Remove any selected file
-      this.setState({
-        filePickerResult: undefined
-      });
-    }
+    this.setState({ filePickerResults });
+
     if (this._listElem) {
       // Force the list to update to show the selection check
       this._listElem.forceUpdate();
@@ -167,8 +160,7 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
   private _renderGridList = (): JSX.Element => {
     return <span className={styles.recentGridList} role="grid">
       <FocusZone>
-        <SelectionZone selection={this._selection}
-          onItemInvoked={(item: IRecentFile) => this._handleItemInvoked(item)}>
+        <SelectionZone selection={this._selection} selectionMode={SelectionMode.multiple} onItemInvoked={(item: IRecentFile) => this._handleItemInvoked(item)}>
           <List
             ref={this._linkElement}
             items={this.state.results}
@@ -188,8 +180,8 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
   private _onRenderCell = (item: IRecentFile, index: number | undefined): JSX.Element => {
     let isSelected: boolean = false;
 
-    if (this._selection && index !== undefined) {
-      isSelected = this._selection.isIndexSelected(index);
+    if (this._selection) {
+      isSelected = this._selection.isKeySelected(item.key);
     }
 
     return (
@@ -249,7 +241,7 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
    * Gets called when it is time to save the currently selected item
    */
   private _handleSave = () => {
-    this.props.onSave([this.state.filePickerResult]);
+    this.props.onSave(this.state.filePickerResults);
   }
 
   /**

--- a/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
+++ b/src/controls/filePicker/RecentFilesTab/RecentFilesTab.tsx
@@ -101,6 +101,7 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
     let filePickerResults: IFilePickerResult[] = [];
     // Get the selected item
     this._selection.getSelection().map((selectedKey: IRecentFile) => {
+      if(!selectedKey.isFolder && selectedKey.fileUrl)
       filePickerResults.push({
         fileAbsoluteUrl: selectedKey.fileUrl,
         fileName: GeneralHelper.getFileNameFromUrl(selectedKey.fileUrl),
@@ -161,7 +162,7 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
       <FocusZone>
         <SelectionZone selection={this._selection}
           selectionMode={SelectionMode.multiple}
-          onItemInvoked={(item: IRecentFile) => this._handleItemInvoked(item)}>
+          onItemInvoked={(item: any) => this._handleItemInvoked(item)}>
           <List
             ref={this._linkElement}
             items={this.state.results}
@@ -235,7 +236,9 @@ export default class RecentFilesTab extends React.Component<IRecentFilesTabProps
    * Gets called what a file is selected.
    */
   private _handleItemInvoked = (item: IRecentFile) => {
-    this._selection.toggleKeySelected(item.key);
+    if(!item.isFolder) {
+      this._selection.toggleKeySelected(item.key);
+    }
   }
 
   /**

--- a/src/controls/filePicker/SiteFilePickerTab/ISiteFilePickerTabState.ts
+++ b/src/controls/filePicker/SiteFilePickerTab/ISiteFilePickerTabState.ts
@@ -1,7 +1,7 @@
 import { IFilePickerResult , FilePickerBreadcrumbItem} from "../FilePicker.types";
 
 export interface ISiteFilePickerTabState {
-  filePickerResult: IFilePickerResult;
+  filePickerResults: IFilePickerResult[];
   libraryAbsolutePath: string;
   libraryUrl: string;
   libraryPath: string;

--- a/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
+++ b/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
@@ -45,7 +45,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
     breadcrumbItems[breadcrumbItems.length - 1].isCurrentItem = true;
 
     this.state = {
-      filePickerResult: null,
+      filePickerResults: [],
       libraryAbsolutePath: folderAbsPath || undefined,
       libraryUrl: libraryServRelUrl || urlCombine(props.context.pageContext.web.serverRelativeUrl, '/Shared%20Documents'),
       libraryPath: folderServRelPath,
@@ -157,7 +157,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
               onOpenLibrary={(selectedLibrary: ILibrary) => this._handleOpenLibrary(selectedLibrary, true)} />}
           {this.state.libraryAbsolutePath !== undefined &&
             <FileBrowser
-              onChange={(filePickerResult: IFilePickerResult) => this._handleSelectionChange(filePickerResult)}
+              onChange={(filePickerResults: IFilePickerResult[]) => this._handleSelectionChange(filePickerResults)}
               onOpenFolder={(folder: IFile) => this._handleOpenFolder(folder, true)}
               fileBrowserService={this.props.fileBrowserService}
               libraryUrl={this.state.libraryUrl}
@@ -167,7 +167,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
         <div className={styles.actionButtonsContainer}>
           <div className={styles.actionButtons}>
             <PrimaryButton
-              disabled={!this.state.filePickerResult}
+              disabled={this.state.filePickerResults && !this.state.filePickerResults.length}
               onClick={() => this._handleSave()} className={styles.actionButton}>{strings.OpenButtonLabel}</PrimaryButton>
             <DefaultButton onClick={() => this._handleClose()} className={styles.actionButton}>{strings.CancelButtonLabel}</DefaultButton>
           </div>
@@ -215,28 +215,26 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
 
     this.setState({
       breadcrumbItems,
-      filePickerResult: undefined
+      filePickerResults: undefined
     });
   }
 
   /**
    * Is called when user selects a different file
    */
-  private _handleSelectionChange = (filePickerResult: IFilePickerResult) => {
-    if (filePickerResult) {
+  private _handleSelectionChange = (filePickerResults: IFilePickerResult[]) => {
+    filePickerResults.map((filePickerResult: IFilePickerResult) => {
       filePickerResult.downloadFileContent = () => { return this.props.fileBrowserService.downloadSPFileContent(filePickerResult.fileAbsoluteUrl, filePickerResult.fileName); };
-    }
-    // this.props.fileBrowserService
-    this.setState({
-      filePickerResult
     });
+    // this.props.fileBrowserService
+    this.setState({ filePickerResults });
   }
 
   /**
    * Called when user saves
    */
   private _handleSave = () => {
-    this.props.onSave([this.state.filePickerResult]);
+    this.props.onSave(this.state.filePickerResults);
   }
 
   /**
@@ -265,7 +263,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
     }
 
     this.setState({
-      filePickerResult: null,
+      filePickerResults: null,
       libraryPath: folder.serverRelativeUrl,
       folderName: folder.name,
       libraryAbsolutePath: folder.absoluteUrl,

--- a/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
+++ b/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
@@ -455,10 +455,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
   private _itemSelectionChanged = () => {
     let filePickerResults: IFilePickerResult[] = [];
     this._selection.getSelection().map((item: IFile, index: number) => {
-      if (item.isFolder) {
-        this._selection.toggleIndexSelected(index);
-      }
-      else {
+      if (!item.isFolder) {
         filePickerResults.push({
           fileAbsoluteUrl: item.absoluteUrl,
           fileName: GeneralHelper.getFileNameFromUrl(item.name),

--- a/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
+++ b/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
@@ -134,7 +134,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
       nextPageQueryString: null,
       loadingState: LoadingState.loading,
       selectedView: lastLayout,
-      filePickerResults: null
+      filePickerResults: []
     };
   }
 
@@ -196,7 +196,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                       />) :
                     (<TilesList
                       fileBrowserService={this.props.fileBrowserService}
-                      filePickerResult={this.state.filePickerResults[0]}
+                      filePickerResult={this.state.filePickerResults ? this.state.filePickerResults[0] : null}
                       selection={this._selection}
                       items={this.state.items}
                       onFolderOpen={this._handleOpenFolder}
@@ -455,10 +455,10 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
   private _itemSelectionChanged = () => {
     let filePickerResults: IFilePickerResult[] = [];
     this._selection.getSelection().map((item: IFile, index: number) => {
-      if(item.isFolder) {
+      if (item.isFolder) {
         this._selection.toggleIndexSelected(index);
       }
-     else {
+      else {
         filePickerResults.push({
           fileAbsoluteUrl: item.absoluteUrl,
           fileName: GeneralHelper.getFileNameFromUrl(item.name),

--- a/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
+++ b/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
@@ -8,7 +8,7 @@ import { IFileBrowserProps } from './IFileBrowserProps';
 import { IFileBrowserState } from './IFileBrowserState';
 import { ViewType } from './FileBrowser.types';
 import { Spinner } from 'office-ui-fabric-react/lib/Spinner';
-import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IColumn, IDetailsRowProps, DetailsRow } from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IColumn, IDetailsRowProps, DetailsRow, IObjectWithKey } from 'office-ui-fabric-react/lib/DetailsList';
 import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane';
@@ -128,17 +128,13 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
       }
     ];
 
-    this._selection = new Selection({
-      selectionMode: SelectionMode.single
-    });
-
     this.state = {
       columns: columns,
       items: [],
       nextPageQueryString: null,
       loadingState: LoadingState.loading,
       selectedView: lastLayout,
-      filePickerResult: null
+      filePickerResults: null
     };
   }
 
@@ -160,6 +156,10 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
    */
   public componentDidMount(): void {
     this._getListItems();
+    this._selection = new Selection({
+      selectionMode: SelectionMode.multiple,
+      onSelectionChanged: this._itemSelectionChanged
+    });
   }
 
   public render(): React.ReactElement<IFileBrowserProps> {
@@ -184,12 +184,11 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                         items={this.state.items}
                         compact={this.state.selectedView === 'compact'}
                         columns={this.state.columns}
-                        selectionMode={SelectionMode.single}
+                        selectionMode={SelectionMode.multiple}
                         setKey="set"
                         layoutMode={DetailsListLayoutMode.justified}
                         isHeaderVisible={true}
                         selection={this._selection}
-                        onActiveItemChanged={(item: IFile, index: number, ev: React.FormEvent<Element>) => this._handleItemInvoked(item)}
                         selectionPreservedOnEmptyClick={true}
                         enterModalSelectionOnTouch={true}
                         onRenderRow={this._onRenderRow}
@@ -197,10 +196,9 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                       />) :
                     (<TilesList
                       fileBrowserService={this.props.fileBrowserService}
-                      filePickerResult={this.state.filePickerResult}
+                      filePickerResult={this.state.filePickerResults[0]}
                       selection={this._selection}
                       items={this.state.items}
-
                       onFolderOpen={this._handleOpenFolder}
                       onFileSelected={this._itemSelectionChanged}
                       onNextPageDataRequest={this._loadNextDataRequest}
@@ -447,53 +445,32 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
     // item in the folder will appear selected
     this.setState({
       loadingState: LoadingState.loading,
-      filePickerResult: undefined
+      filePickerResults: undefined
     }, () => { this.props.onOpenFolder(item); });
   }
 
   /**
    * Handles selected item change
    */
-  private _itemSelectionChanged = (item?: IFile) => {
-    let selectedItem: IFile = null;
-    // Deselect item
-    if (item && this.state.filePickerResult && item.absoluteUrl == this.state.filePickerResult.fileAbsoluteUrl) {
-      this._selection.setAllSelected(false);
-      selectedItem = null;
-    }
-    else if (item) {
-      const selectedItemIndex = this.state.items.indexOf(item);
-      this._selection.selectToIndex(selectedItemIndex);
-      selectedItem = item;
-    }
-
-    let filePickerResult: IFilePickerResult = null;
-    if (selectedItem && !selectedItem.isFolder) {
-      filePickerResult = {
-        fileAbsoluteUrl: selectedItem.absoluteUrl,
-        fileName: GeneralHelper.getFileNameFromUrl(selectedItem.name),
-        fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(selectedItem.name),
-        spItemUrl: selectedItem.spItemUrl,
-        downloadFileContent: null
-      };
-    }
-    this.props.onChange(filePickerResult);
-    this.setState({
-      filePickerResult
+  private _itemSelectionChanged = () => {
+    let filePickerResults: IFilePickerResult[] = [];
+    this._selection.getSelection().map((item: IFile, index: number) => {
+      if(item.isFolder) {
+        this._selection.toggleIndexSelected(index);
+      }
+     else {
+        filePickerResults.push({
+          fileAbsoluteUrl: item.absoluteUrl,
+          fileName: GeneralHelper.getFileNameFromUrl(item.name),
+          fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(item.name),
+          spItemUrl: item.spItemUrl,
+          downloadFileContent: null
+        });
+      }
     });
-  }
 
-  /**
-   * Handles item click.
-   */
-  private _handleItemInvoked = (item: IFile) => {
-    // If a file is selected, open the library
-    if (item.isFolder) {
-      this._handleOpenFolder(item);
-    } else {
-      // Otherwise, remember it was selected
-      this._itemSelectionChanged(item);
-    }
+    this.props.onChange(filePickerResults);
+    this.setState({ filePickerResults });
   }
 
   /**

--- a/src/controls/filePicker/controls/FileBrowser/IFileBrowserProps.ts
+++ b/src/controls/filePicker/controls/FileBrowser/IFileBrowserProps.ts
@@ -7,6 +7,6 @@ export interface IFileBrowserProps {
   libraryUrl: string;
   folderPath: string;
   accepts: string[];
-  onChange: (filePickerResult: IFilePickerResult) => void;
+  onChange: (filePickerResult: IFilePickerResult[]) => void;
   onOpenFolder: (folder: IFile) => void;
 }

--- a/src/controls/filePicker/controls/FileBrowser/IFileBrowserState.ts
+++ b/src/controls/filePicker/controls/FileBrowser/IFileBrowserState.ts
@@ -16,7 +16,7 @@ export interface IFileBrowserState {
   items: IFile[];
   nextPageQueryString: string;
   // currentPath: string;
-  filePickerResult: IFilePickerResult;
+  filePickerResults: IFilePickerResult[];
   columns: IColumn[];
   selectedView: ViewType;
 }

--- a/src/controls/filePicker/controls/TilesList/TilesList.tsx
+++ b/src/controls/filePicker/controls/TilesList/TilesList.tsx
@@ -67,7 +67,6 @@ export class TilesList extends React.Component<ITilesListProps> {
             ref={(e:any) => { this._listElem = e; }}
             className={styles.folderList}
             items={this.props.items}
-
             getItemCountForPage={this._getItemCountForPage}
             getPageHeight={this._getPageHeight}
             onRenderPage={(pageProps: IPageProps, defaultRender?: IRenderFunction<IPageProps>) => this._onRenderPage(pageProps, defaultRender)}

--- a/src/services/FilesSearchService.ts
+++ b/src/services/FilesSearchService.ts
@@ -224,7 +224,8 @@ export class FilesSearchService {
       key: keyCell ? keyCell.Value : null,
       name: titleCell ? titleCell.Value : null,
       fileUrl: fileUrlCell ? fileUrlCell.Value : null,
-      editedBy: editedByCell ? editedByCell.Value : null
+      editedBy: editedByCell ? editedByCell.Value : null,
+      isFolder: !fileUrlCell.Value
     };
     return recentFile;
   }

--- a/src/services/FilesSearchService.types.ts
+++ b/src/services/FilesSearchService.types.ts
@@ -3,6 +3,7 @@ export interface IRecentFile {
   key: string;
   name: string;
   editedBy: string;
+  isFolder: boolean;
 }
 
 export interface BingQuerySearchParams {


### PR DESCRIPTION
…s for FilePicker component

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | fixes #725 

#### What's in this Pull Request?

The current version of the FilePicker doesn't support multiple selections for files.
I have changed the selection mode to multiple for Recent, OneDrive and Site Files tabs. 
The folders cannot be selected but could be opened and multiple selections apply inside. 


