### PR TITLE
Add useSessionStorage, onPanelSelectionChange and selectChildrenIfParentSelected to Taxonomy Picker Control

### DIFF
--- a/src/common/utilities/LocalesHelper.ts
+++ b/src/common/utilities/LocalesHelper.ts
@@ -1,3 +1,5 @@
+import { findIndex } from '@microsoft/sp-lodash-subset';
+
 export class LocalesHelper {
 
   private static locales = {
@@ -53,7 +55,7 @@ export class LocalesHelper {
     10266: 'sr-Cyrl-RS',
   };
   public static getLocaleId(localeName: string): number {
-    const pos: number = Object.keys(this.locales).findIndex(locKey => this.locales[locKey] === localeName);
+    const pos: number = findIndex(Object.keys(this.locales), locKey => this.locales[locKey] === localeName);
     if (pos > -1) {
       return parseInt(Object.keys(this.locales)[pos]);
     }

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -25,7 +25,7 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
   private dropArea = null;
   private dropRef = element => {
     this.dropArea = element;
-  };
+  }
 
   constructor(props: IListViewProps) {
     super(props);

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -120,6 +120,12 @@ export interface ITaxonomyPickerProps  {
    * Note that error message should be specified in onGetErrorMessage
    */
   required?: boolean;
+
+  /**
+   * Specifies if you want to use session storage
+   * Default will be true
+   */
+   useSessionStorage?: boolean;
 }
 
 /**

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -1,4 +1,4 @@
-import { IPickerTerms } from './ITermPicker';
+import { IPickerTerm, IPickerTerms } from './ITermPicker';
 import { ITermSet, ITerm } from '../../services/ISPTermStorePickerService';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
 import { ITermActions } from './termActions/ITermsActions';
@@ -126,6 +126,17 @@ export interface ITaxonomyPickerProps  {
    * Default will be true
    */
    useSessionStorage?: boolean;
+
+   /**
+   * Panel selection change handler. Can be used to interact with the control while selecting items in the panel, before Click or Cancel is clicked.
+   */
+  onPanelSelectionChange?: (prevValue: IPickerTerms, newValue: IPickerTerms) => void;
+
+  /**
+   * Specifies if the childrens should be selected when parent is selected.
+   * By default this is set to false.
+   */
+  selectChildrenIfParentSelected?: boolean;
 }
 
 /**

--- a/src/controls/taxonomyPicker/TaxonomyPicker.tsx
+++ b/src/controls/taxonomyPicker/TaxonomyPicker.tsx
@@ -111,7 +111,8 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
       hideTagsNotAvailableForTagging,
       initialValues,
       validateOnLoad,
-      termsetNameOrID
+      termsetNameOrID,
+      useSessionStorage
     } = this.props;
 
     let isValidateOnLoad = validateOnLoad && initialValues && initialValues.length >= 1;
@@ -120,7 +121,7 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
       const notFoundTerms: string[] = [];
       const notFoundTermIds: string[] = [];
 
-      const termSet = await this.termsService.getAllTerms(termsetNameOrID, hideDeprecatedTags, hideTagsNotAvailableForTagging);
+      const termSet = await this.termsService.getAllTerms(termsetNameOrID, hideDeprecatedTags, hideTagsNotAvailableForTagging, useSessionStorage);
       const allTerms = termSet.Terms;
 
       for (let i = 0, len = initialValues.length; i < len; i++) {
@@ -152,7 +153,7 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
       // });
     }
 
-    this.termsService.getAllTerms(this.props.termsetNameOrID, this.props.hideDeprecatedTags, this.props.hideTagsNotAvailableForTagging).then((response: ITermSet) => {
+    this.termsService.getAllTerms(this.props.termsetNameOrID, this.props.hideDeprecatedTags, this.props.hideTagsNotAvailableForTagging, this.props.useSessionStorage).then((response: ITermSet) => {
       // Check if a response was retrieved
       let termSetAndTerms = response ? response : null;
       this.setState({
@@ -166,7 +167,7 @@ export class TaxonomyPicker extends React.Component<ITaxonomyPickerProps, ITaxon
    * Force update of the taxonomy tree - required by term action in case the term has been added, deleted or moved.
    */
   private async updateTaxonomyTree(): Promise<void> {
-    const termSetAndTerms = await this.termsService.getAllTerms(this.props.termsetNameOrID, this.props.hideDeprecatedTags, this.props.hideTagsNotAvailableForTagging);
+    const termSetAndTerms = await this.termsService.getAllTerms(this.props.termsetNameOrID, this.props.hideDeprecatedTags, this.props.hideTagsNotAvailableForTagging, this.props.useSessionStorage);
 
     this.setState({
       termSetAndTerms

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -658,6 +658,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
         <div className="ms-font-m">Services tester:
           <TaxonomyPicker
             allowMultipleSelections={true}
+            selectChildrenIfParentSelected={true}
             //termsetNameOrID="61837936-29c5-46de-982c-d1adb6664b32" // id to termset that has a custom sort
             termsetNameOrID="8ea5ac06-fd7c-4269-8d0d-02f541df8eb9"
             initialValues={[{
@@ -708,6 +709,10 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
               ],
               termActionsDisplayMode: TermActionsDisplayMode.buttons,
               termActionsDisplayStyle: TermActionsDisplayStyle.textAndIcon
+            }}
+            onPanelSelectionChange={(prev, next) => {
+              console.log(prev);
+              console.log(next);
             }}
           />
 


### PR DESCRIPTION

| New feature?    | [x]
| Related issues?  | fixes #998

What's in this Pull Request?
The version 1 of the taxonomy picker doesn't have some useful properties. 
Add useSessionStorage, onPanelSelectionChange and selectChildrenIfParentSelected properties to taxonomy picker control.
