### PR TITLE
Added feature to add action button to terms in ModernTaxonomyPicker

### DIFF
--- a/docs/documentation/docs/controls/ModernTaxonomyPicker.md
+++ b/docs/documentation/docs/controls/ModernTaxonomyPicker.md
@@ -156,7 +156,7 @@ You can also use the `TaxonomyTree` control separately to just render a stand-al
 
 ```TypeScript
       const taxonomyService = new SPTaxonomyService(props.context);
-      const [terms, setTerms] = React.useState<ITermInfo[]>();
+      const [terms, setTerms] = React.useState<ITermInfo[]>([]);
       const [currentTermStoreInfo, setCurrentTermStoreInfo] = React.useState<ITermStoreInfo>();
       const [currentTermSetInfo, setCurrentTermSetInfo] = React.useState<ITermSetInfo>();
       const [currentLanguageTag, setCurrentLanguageTag] = React.useState<string>("");
@@ -176,16 +176,21 @@ You can also use the `TaxonomyTree` control separately to just render a stand-al
           });
       }, []);
 
-      <TaxonomyTree
-        languageTag={currentLanguageTag}
-        onLoadMoreData={taxonomyService.getTerms}
-        pageSize={50}
-        setTerms={setTerms}
-        termSetInfo={currentTermSetInfo}
-        termStoreInfo={currentTermStoreInfo}
-        terms={terms}
-        onRenderActionButton={onRenderActionButton}
-      />
+      return (
+        {currentTermSetInfo && (  
+          <TaxonomyTree
+            languageTag={currentLanguageTag}
+            onLoadMoreData={taxonomyService.getTerms}
+            pageSize={50}
+            setTerms={setTerms}
+            termSetInfo={currentTermSetInfo}
+            termStoreInfo={currentTermStoreInfo}
+            terms={terms}
+            onRenderActionButton={onRenderActionButton}
+            hideDeprecatedTerms={false}
+            showIcons={true}
+          />
+        )}
 ```
 
 ![](https://telemetry.sharepointpnp.com/sp-dev-fx-controls-react/wiki/controls/ModernTaxonomyPicker)

--- a/docs/documentation/docs/controls/ModernTaxonomyPicker.md
+++ b/docs/documentation/docs/controls/ModernTaxonomyPicker.md
@@ -68,7 +68,7 @@ Custom rendering of a More actions button that displays a context menu for each 
   customPanelWidth={700}
   isLightDismiss={false}
   isBlocking={false}
-  onRenderActionButton={(termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo?: ITermInfo) => {
+  onRenderActionButton={(termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo?: ITermInfo): JSX.Element => {
     const menuIcon: IIconProps = { iconName: 'MoreVertical', "aria-label": "More actions", style: { fontSize: "medium" } };
     if (termInfo) {
       const menuProps: IContextualMenuProps = {
@@ -147,4 +147,45 @@ The ModernTaxonomyPicker control can be configured with the following properties
 | isBlocking | boolean | no | Whether the panel uses a modal overlay or not. |
 | onRenderActionButton | function | no | Optional custom renderer for adding e.g. a button with additional actions to the terms in the tree view. |
 
-![](https://telemetry.sharepointpnp.com/sp-dev-fx-controls-react/wiki/controls/TaxonomyPicker)
+## Standalone TaxonomyTree control
+
+You can also use the `TaxonomyTree` control separately to just render a stand-alone tree-view of a term set with action buttons.
+
+- Use the `TaxonomyTree` control in your code as follows:  
+  Initialize the taxonomy service and state, load basic info from term store and display the `TaxonomyTree` component.
+
+```TypeScript
+      const taxonomyService = new SPTaxonomyService(props.context);
+      const [terms, setTerms] = React.useState<ITermInfo[]>();
+      const [currentTermStoreInfo, setCurrentTermStoreInfo] = React.useState<ITermStoreInfo>();
+      const [currentTermSetInfo, setCurrentTermSetInfo] = React.useState<ITermSetInfo>();
+      const [currentLanguageTag, setCurrentLanguageTag] = React.useState<string>("");
+
+      React.useEffect(() => {
+        sp.setup(props.context);
+        taxonomyService.getTermStoreInfo()
+          .then((termStoreInfo) => {
+            setCurrentTermStoreInfo(termStoreInfo);
+            setCurrentLanguageTag(props.context.pageContext.cultureInfo.currentUICultureName !== '' ?
+              props.context.pageContext.cultureInfo.currentUICultureName :
+              currentTermStoreInfo.defaultLanguageTag);
+          });
+        taxonomyService.getTermSetInfo(Guid.parse(props.termSetId))
+          .then((termSetInfo) => {
+            setCurrentTermSetInfo(termSetInfo);
+          });
+      }, []);
+
+      <TaxonomyTree
+        languageTag={currentLanguageTag}
+        onLoadMoreData={taxonomyService.getTerms}
+        pageSize={50}
+        setTerms={setTerms}
+        termSetInfo={currentTermSetInfo}
+        termStoreInfo={currentTermStoreInfo}
+        terms={terms}
+        onRenderActionButton={onRenderActionButton}
+      />
+```
+
+![](https://telemetry.sharepointpnp.com/sp-dev-fx-controls-react/wiki/controls/ModernTaxonomyPicker)

--- a/docs/documentation/docs/controls/ModernTaxonomyPicker.md
+++ b/docs/documentation/docs/controls/ModernTaxonomyPicker.md
@@ -35,11 +35,12 @@ import { ModernTaxonomyPicker } from "@pnp/spfx-controls-react/lib/ModernTaxonom
 
 ```TypeScript
 <ModernTaxonomyPicker allowMultipleSelections={true}
-                termSetId="f233d4b7-68fb-41ef-8b58-2af0bafc0d38"
-                panelTitle="Select Term"
-                label="Taxonomy Picker"
-                context={this.props.context}
-                onChange={this.onTaxPickerChange} />
+  termSetId="f233d4b7-68fb-41ef-8b58-2af0bafc0d38"
+  panelTitle="Select Term"
+  label="Taxonomy Picker"
+  context={this.props.context}
+  onChange={this.onTaxPickerChange}
+/>
 ```
 
 - With the `onChange` property you can capture the event of when the terms in the picker has changed:
@@ -48,6 +49,78 @@ import { ModernTaxonomyPicker } from "@pnp/spfx-controls-react/lib/ModernTaxonom
 private onTaxPickerChange(terms : ITermInfo[]) {
   console.log("Terms", terms);
 }
+```
+
+## Advanced example
+Custom rendering of a More actions button that displays a context menu for each term in the term set and the term set itself and with different options for the terms and the term set. This could for example be used to add terms to an open term set. It also shows how to set the initialsValues property when just knowing the name and the id of the term, the rest of the term properties must be provided but doesn't need to be the correct values.
+
+```TypeScript
+<ModernTaxonomyPicker
+  allowMultipleSelections={true}
+  termSetId={"36d21c3f-b83b-4acc-a223-4df6fa8e946d"}
+  panelTitle="Panel title"
+  label={"Field title"}
+  context={this.props.context}
+  required={false}
+  initialValues={[{labels: [{name: "Subprocess A1", isDefault: true, languageTag: "en-US"}], id: "29eced8f-cf08-454b-bd9e-6443bc0a0f5e", childrenCount: 0, createdDateTime: "", lastModifiedDateTime: "", descriptions: [], customSortOrder: [], properties: [], localProperties: [], isDeprecated: false, isAvailableForTagging: [], topicRequested: false}]}
+  onChange={this.onTaxPickerChange}
+  disabled={false}
+  customPanelWidth={700}
+  isLightDismiss={false}
+  isBlocking={false}
+  onRenderActionButton={(termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo?: ITermInfo) => {
+    const menuIcon: IIconProps = { iconName: 'MoreVertical', "aria-label": "More actions", style: { fontSize: "medium" } };
+    if (termInfo) {
+      const menuProps: IContextualMenuProps = {
+        items: [
+          {
+            key: 'addTerm',
+            text: 'Add Term',
+            iconProps: { iconName: 'Tag' },
+            onClick: () => onContextualMenuClick(termInfo.id)
+          },
+          {
+            key: 'deleteTerm',
+            text: 'Delete term',
+            iconProps: { iconName: 'Untag' },
+            onClick: () => onContextualMenuClick(termInfo.id)
+          },
+        ],
+      };
+
+      return (
+        <IconButton
+          menuProps={menuProps}
+          menuIconProps={menuIcon}
+          style={this.state.clickedActionTerm && this.state.clickedActionTerm.id === termInfo.id ? {opacity: 1} : null}
+          onMenuClick={(ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>, button?: IButtonProps) => {
+            this.setState({clickedActionTerm: termInfo});
+          }}
+          onAfterMenuDismiss={() => this.setState({clickedActionTerm: null})}
+        />
+      );
+    }
+    else {
+      const menuProps: IContextualMenuProps = {
+        items: [
+          {
+            key: 'addTerm',
+            text: 'Add term',
+            iconProps: { iconName: 'Tag' },
+            onClick: () => onContextualMenuClick(termSetInfo.id)
+          },
+        ],
+      };
+      return (
+        <IconButton
+          menuProps={menuProps}
+          menuIconProps={menuIcon}
+          style={{opacity: 1}}
+        />
+      );
+    }
+  }}
+/>
 ```
 
 ## Implementation
@@ -70,5 +143,8 @@ The ModernTaxonomyPicker control can be configured with the following properties
 | customPanelWidth | number | no | Custom panel width in pixels. |
 | termPickerProps | IModernTermPickerProps | no | Custom properties for the term picker (More info: [IBasePickerProps interface](https://developer.microsoft.com/en-us/fluentui#/controls/web/pickers#IBasePickerProps)).  |
 | themeVariant | IReadonlyTheme | no | The current loaded SharePoint theme/section background (More info: [Supporting section backgrounds](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/web-parts/guidance/supporting-section-backgrounds)). |
+| isLightDismiss | boolean | no | Whether the panel can be light dismissed. |
+| isBlocking | boolean | no | Whether the panel uses a modal overlay or not. |
+| onRenderActionButton | function | no | Optional custom renderer for adding e.g. a button with additional actions to the terms in the tree view. |
 
 ![](https://telemetry.sharepointpnp.com/sp-dev-fx-controls-react/wiki/controls/TaxonomyPicker)

--- a/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
+++ b/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
@@ -60,6 +60,9 @@ export interface IModernTaxonomyPickerProps {
   customPanelWidth?: number;
   themeVariant?: IReadonlyTheme;
   termPickerProps?: Optional<IModernTermPickerProps, 'onResolveSuggestions'>;
+  isLightDismiss?: boolean;
+  isBlocking?: boolean;
+  onRenderActionButton?: (termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo?: ITermInfo) => JSX.Element;
 }
 
 export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps) {
@@ -235,7 +238,8 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps) {
         hasCloseButton={true}
         closeButtonAriaLabel={strings.ModernTaxonomyPickerPanelCloseButtonText}
         onDismiss={onClosePanel}
-        isLightDismiss={true}
+        isLightDismiss={props.isLightDismiss}
+        isBlocking={props.isBlocking}
         type={props.customPanelWidth ? PanelType.custom : PanelType.medium}
         customWidth={props.customPanelWidth ? `${props.customPanelWidth}px` : undefined}
         headerText={props.panelTitle}
@@ -273,6 +277,7 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps) {
                 languageTag={currentLanguageTag}
                 themeVariant={props.themeVariant}
                 termPickerProps={props.termPickerProps}
+                onRenderActionButton={props.onRenderActionButton}
               />
             </div>
           )

--- a/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
+++ b/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
@@ -66,7 +66,7 @@ export interface IModernTaxonomyPickerProps {
 }
 
 export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps) {
-  const [taxonomyService] = React.useState(() => new SPTaxonomyService(props.context));
+  const taxonomyService = new SPTaxonomyService(props.context);
   const [panelIsOpen, setPanelIsOpen] = React.useState(false);
   const [selectedOptions, setSelectedOptions] = React.useState<ITermInfo[]>([]);
   const [selectedPanelOptions, setSelectedPanelOptions] = React.useState<ITermInfo[]>([]);
@@ -265,8 +265,6 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps) {
                 anchorTermInfo={currentAnchorTermInfo}
                 termSetInfo={currentTermSetInfo}
                 termStoreInfo={currentTermStoreInfo}
-                context={props.context}
-                termSetId={Guid.parse(props.termSetId)}
                 pageSize={50}
                 selectedPanelOptions={selectedPanelOptions}
                 setSelectedPanelOptions={setSelectedPanelOptions}

--- a/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
+++ b/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
@@ -50,7 +50,7 @@ export interface IModernTaxonomyPickerProps {
   panelTitle: string;
   label: string;
   context: BaseComponentContext;
-  initialValues?: ITermInfo[];
+  initialValues?: Optional<ITermInfo, "childrenCount" | "createdDateTime" | "lastModifiedDateTime" | "descriptions" | "customSortOrder" | "properties" | "localProperties" | "isDeprecated" | "isAvailableForTagging" | "topicRequested">[];
   disabled?: boolean;
   required?: boolean;
   onChange?: (newValue?: ITermInfo[]) => void;

--- a/src/controls/modernTaxonomyPicker/index.ts
+++ b/src/controls/modernTaxonomyPicker/index.ts
@@ -1,2 +1,6 @@
 export * from './ModernTaxonomyPicker';
-export * from './termItem/TermItem';
+export * from './modernTermPicker/index';
+export * from './taxonomyPanelContents/index';
+export * from './taxonomyTree/index';
+export * from './termItem/index';
+export * from '../../services/SPTaxonomyService';

--- a/src/controls/modernTaxonomyPicker/modernTermPicker/ModernTermPicker.types.ts
+++ b/src/controls/modernTaxonomyPicker/modernTermPicker/ModernTermPicker.types.ts
@@ -38,7 +38,7 @@ export interface ITermItemStyles {
   close: IStyle;
 }
 
-export interface ITermItemSuggestionProps extends React.AllHTMLAttributes<HTMLElement> {
+export interface ITermItemSuggestionElementProps extends React.AllHTMLAttributes<HTMLElement> {
   /** Additional CSS class(es) to apply to the TermItemSuggestion div element */
   className?: string;
 
@@ -49,8 +49,8 @@ export interface ITermItemSuggestionProps extends React.AllHTMLAttributes<HTMLEl
   theme?: ITheme;
 }
 
-export type ITermItemSuggestionStyleProps = Required<Pick<ITermItemSuggestionProps, 'theme'>> &
-  Pick<ITermItemSuggestionProps, 'className'> & {};
+export type ITermItemSuggestionStyleProps = Required<Pick<ITermItemSuggestionElementProps, 'theme'>> &
+  Pick<ITermItemSuggestionElementProps, 'className'> & {};
 
 export interface ITermItemSuggestionStyles {
   /** Refers to the text element of the TermItemSuggestion */

--- a/src/controls/modernTaxonomyPicker/modernTermPicker/index.ts
+++ b/src/controls/modernTaxonomyPicker/modernTermPicker/index.ts
@@ -1,0 +1,2 @@
+export * from './ModernTermPicker';
+export * from './ModernTermPicker.types';

--- a/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.module.scss
+++ b/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.module.scss
@@ -1,36 +1,6 @@
 @import '~office-ui-fabric-react/dist/sass/References.scss';
 
 .taxonomyPanelContents {
-  .choiceOption {
-    color: "[theme: bodyText, default: #323130]";
-    display: inline-block;
-    padding-inline-start: 26px;
-  }
-
-  .disabledChoiceOption {
-    color: "[theme: disabledBodyText, default: #323130]";
-    display: inline-block;
-    padding-inline-start: 26px;
-  }
-
-  .selectedChoiceOption {
-    font-weight: bold;
-  }
-
-  .checkbox {
-    color: "[theme: bodyText, default: #323130]";
-    margin-inline-start: 4px;
-  }
-
-  .disabledCheckbox {
-    color: "[theme: disabledBodyText, default: #323130]";
-    margin-inline-start: 4px;
-  }
-
-  .selectedCheckbox {
-    font-weight: bold;
-  }
-
   .taxonomyTreeSelector {
     border-bottom-color: blue;
     border-bottom-style: solid;
@@ -41,36 +11,5 @@
   .taxonomyTreeLabel {
     font-size: 18px;
     font-weight: 100;
-  }
-
-  .spinnerContainer {
-    height: 48px;
-    line-height: 48px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
-  .loadMoreContainer {
-    height: 48px;
-    line-height: 48px;
-  }
-
-  .taxonomyItemFocusZone {
-    display: flex;
-    align-items: center;
-    width: 100%;
-  }
-
-  .taxonomyItemHeader {
-    width: 100%;
-  }
-
-  .taxonomyItemHeader .actionButtonContainer > * {
-    opacity: 0;
-  }
-
-  .taxonomyItemHeader:hover .actionButtonContainer > *, .taxonomyItemHeader:focus .actionButtonContainer > *, .taxonomyItemHeader .actionButtonContainer:focus-within > * {
-    opacity: 1;
   }
 }

--- a/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.module.scss
+++ b/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.module.scss
@@ -55,4 +55,22 @@
     height: 48px;
     line-height: 48px;
   }
+
+  .taxonomyItemFocusZone {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+
+  .taxonomyItemHeader {
+    width: 100%;
+  }
+
+  .taxonomyItemHeader .actionButtonContainer > * {
+    opacity: 0;
+  }
+
+  .taxonomyItemHeader:hover .actionButtonContainer > *, .taxonomyItemHeader:focus .actionButtonContainer > *, .taxonomyItemHeader .actionButtonContainer:focus-within > * {
+    opacity: 1;
+  }
 }

--- a/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.tsx
@@ -112,6 +112,8 @@ export function TaxonomyPanelContents(props: ITaxonomyPanelContentsProps): React
         terms={terms}
         allowMultipleSelections={props.allowMultipleSelections}
         onRenderActionButton={props.onRenderActionButton}
+        hideDeprecatedTerms={true}
+        showIcons={false}
       />
     </div>
   );

--- a/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.tsx
@@ -38,7 +38,7 @@ export interface ITaxonomyPanelContentsProps {
   languageTag: string;
   themeVariant?: IReadonlyTheme;
   termPickerProps?: Optional<IModernTermPickerProps, 'onResolveSuggestions'>;
-  onRenderActionButton?: (termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo?: ITermInfo) => JSX.Element;
+  onRenderActionButton?: (termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo: ITermInfo, updateTaxonomyTreeViewCallback?: (newTermItems?: ITermInfo[], updatedTermItems?: ITermInfo[], deletedTermItems?: ITermInfo[]) => void) => JSX.Element;
 }
 
 export function TaxonomyPanelContents(props: ITaxonomyPanelContentsProps): React.ReactElement<ITaxonomyPanelContentsProps> {

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.module.scss
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.module.scss
@@ -60,3 +60,8 @@
 .taxonomyItemHeader:hover .actionButtonContainer > *, .taxonomyItemHeader:focus .actionButtonContainer > *, .taxonomyItemHeader .actionButtonContainer:focus-within > * {
   opacity: 1;
 }
+
+.taxonomyItemIcon {
+  margin-inline-start: 8px;
+  margin-inline-end: 8px;
+}

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.module.scss
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.module.scss
@@ -1,0 +1,62 @@
+@import '~office-ui-fabric-react/dist/sass/References.scss';
+
+.choiceOption {
+  color: "[theme: bodyText, default: #323130]";
+  display: inline-block;
+  padding-inline-start: 26px;
+}
+
+.disabledChoiceOption {
+  color: "[theme: disabledBodyText, default: #323130]";
+  display: inline-block;
+  padding-inline-start: 26px;
+}
+
+.selectedChoiceOption {
+  font-weight: bold;
+}
+
+.checkbox {
+  color: "[theme: bodyText, default: #323130]";
+  margin-inline-start: 4px;
+}
+
+.disabledCheckbox {
+  color: "[theme: disabledBodyText, default: #323130]";
+  margin-inline-start: 4px;
+}
+
+.selectedCheckbox {
+  font-weight: bold;
+}
+
+.spinnerContainer {
+  height: 48px;
+  line-height: 48px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.loadMoreContainer {
+  height: 48px;
+  line-height: 48px;
+}
+
+.taxonomyItemFocusZone {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.taxonomyItemHeader {
+  width: 100%;
+}
+
+.taxonomyItemHeader .actionButtonContainer > * {
+  opacity: 0;
+}
+
+.taxonomyItemHeader:hover .actionButtonContainer > *, .taxonomyItemHeader:focus .actionButtonContainer > *, .taxonomyItemHeader .actionButtonContainer:focus-within > * {
+  opacity: 1;
+}

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
@@ -215,8 +215,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
     if (props.termSetInfo.childrenCount > 0) {
       props.onLoadMoreData(Guid.parse(props.termSetInfo.id), props.anchorTermInfo ? Guid.parse(props.anchorTermInfo.id) : Guid.empty, '', props.hideDeprecatedTerms)
         .then((loadedTerms) => {
-          const nonExistingTerms = loadedTerms.value.filter((term) => props.terms.every((prevTerm) => prevTerm.id !== term.id));
-          const grps: IGroup[] = nonExistingTerms.map(term => {
+          const grps: IGroup[] = loadedTerms.value.map(term => {
             let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
             if (termNames.length === 0) {
               termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.termStoreInfo.defaultLanguageTag && termLabel.isDefault === true));
@@ -237,6 +236,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
             return g;
           });
           props.setTerms((prevTerms) => {
+            const nonExistingTerms = loadedTerms.value.filter((newTerm) => prevTerms.every((prevTerm) => prevTerm.id !== newTerm.id));
             return [...prevTerms, ...nonExistingTerms];
           });
           rootGroup.children = grps;
@@ -276,8 +276,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
 
         props.onLoadMoreData(Guid.parse(props.termSetInfo.id), Guid.parse(group.key), '', props.hideDeprecatedTerms)
           .then((loadedTerms) => {
-            const nonExistingTerms = loadedTerms.value.filter((term) => props.terms.every((prevTerm) => prevTerm.id !== term.id));
-            const grps: IGroup[] = nonExistingTerms.map(term => {
+            const grps: IGroup[] = loadedTerms.value.map(term => {
               let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
               if (termNames.length === 0) {
                 termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.termStoreInfo.defaultLanguageTag && termLabel.isDefault === true));
@@ -299,10 +298,12 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
             });
 
             props.setTerms((prevTerms) => {
+              const nonExistingTerms = loadedTerms.value.filter((newTerm) => prevTerms.every((prevTerm) => prevTerm.id !== newTerm.id));
               return [...prevTerms, ...nonExistingTerms];
             });
 
-            group.children = grps;
+            const nonExistingChildren = grps.filter((grp) => group.children?.every((child) => child.key !== grp.key));
+            group.children = nonExistingChildren;
             group.data.skiptoken = loadedTerms.skiptoken;
             group.hasMoreData = loadedTerms.skiptoken !== '';
             setGroupsLoading((prevGroupsLoading) => prevGroupsLoading.filter((value) => value !== group.key));
@@ -513,8 +514,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
             setGroupsLoading((prevGroupsLoading) => [...prevGroupsLoading, footerProps.group.key]);
             props.onLoadMoreData(Guid.parse(props.termSetInfo.id), footerProps.group.key === props.termSetInfo.id ? Guid.empty : Guid.parse(footerProps.group.key), footerProps.group.data.skiptoken, props.hideDeprecatedTerms)
               .then((loadedTerms) => {
-                const nonExistingTerms = loadedTerms.value.filter((term) => props.terms.every((prevTerm) => prevTerm.id !== term.id));
-                const grps: IGroup[] = nonExistingTerms.map(term => {
+                const grps: IGroup[] = loadedTerms.value.map(term => {
                   let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
                   if (termNames.length === 0) {
                     termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.termStoreInfo.defaultLanguageTag && termLabel.isDefault === true));
@@ -535,9 +535,11 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
                   return g;
                 });
                 props.setTerms((prevTerms) => {
+                  const nonExistingTerms = loadedTerms.value.filter((newTerm) => prevTerms.every((prevTerm) => prevTerm.id !== newTerm.id));
                   return [...prevTerms, ...nonExistingTerms];
                 });
-                footerProps.group.children = [...footerProps.group.children, ...grps];
+                const nonExistingChildren = grps.filter((grp) => footerProps.group.children?.every((child) => child.key !== grp.key));
+                footerProps.group.children = [...footerProps.group.children, ...nonExistingChildren];
                 footerProps.group.data.skiptoken = loadedTerms.skiptoken;
                 footerProps.group.hasMoreData = loadedTerms.skiptoken !== '';
                 setGroupsLoading((prevGroupsLoading) => prevGroupsLoading.filter((value) => value !== footerProps.group.key));

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
@@ -1,0 +1,445 @@
+import * as React from 'react';
+import { Checkbox,
+         ChoiceGroup,
+         css,
+         FocusZone,
+         FocusZoneDirection,
+         getRTLSafeKeyCode,
+         GroupedList,
+         GroupHeader,
+         ICheckboxStyleProps,
+         ICheckboxStyles,
+         IChoiceGroupOption,
+         IChoiceGroupOptionStyleProps,
+         IChoiceGroupOptionStyles,
+         IChoiceGroupStyleProps,
+         IChoiceGroupStyles,
+         IGroup,
+         IGroupFooterProps,
+         IGroupHeaderProps,
+         IGroupHeaderStyleProps,
+         IGroupHeaderStyles,
+         IGroupRenderProps,
+         IGroupShowAllProps,
+         ILabelStyleProps,
+         ILabelStyles,
+         ILinkStyleProps,
+         ILinkStyles,
+         IListProps,
+         IRenderFunction,
+         ISpinnerStyleProps,
+         ISpinnerStyles,
+         IStyleFunctionOrObject,
+         KeyCodes,
+         Label,
+         Link,
+         Selection,
+         Spinner
+       } from 'office-ui-fabric-react';
+import * as strings from 'ControlStrings';
+import { IReadonlyTheme } from '@microsoft/sp-component-base';
+import { Guid } from '@microsoft/sp-core-library';
+import { ITermInfo, ITermSetInfo, ITermStoreInfo } from '@pnp/sp/taxonomy';
+import styles from './TaxonomyTree.module.scss';
+
+export interface ITaxonomyTreeProps {
+  allowMultipleSelections?: boolean;
+  pageSize: number;
+  onLoadMoreData: (termSetId: Guid, parentTermId?: Guid, skiptoken?: string, hideDeprecatedTerms?: boolean, pageSize?: number) => Promise<{ value: ITermInfo[], skiptoken: string }>;
+  anchorTermInfo?: ITermInfo;
+  termSetInfo: ITermSetInfo;
+  termStoreInfo: ITermStoreInfo;
+  languageTag: string;
+  themeVariant?: IReadonlyTheme;
+  onRenderActionButton?: (termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo?: ITermInfo) => JSX.Element;
+  terms: ITermInfo[];
+  setTerms: React.Dispatch<React.SetStateAction<ITermInfo[]>>;
+  selection?: Selection<any>;
+}
+
+export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITaxonomyTreeProps> {
+  const [groupsLoading, setGroupsLoading] = React.useState<string[]>([]);
+  const [groups, setGroups] = React.useState<IGroup[]>([]);
+
+  React.useEffect(() => {
+    let termRootName = "";
+    if (props.anchorTermInfo) {
+      let anchorTermNames = props.anchorTermInfo.labels.filter((name) => name.languageTag === props.languageTag && name.isDefault);
+      if (anchorTermNames.length === 0) {
+        anchorTermNames = props.anchorTermInfo.labels.filter((name) => name.languageTag === props.termStoreInfo.defaultLanguageTag && name.isDefault);
+      }
+      termRootName = anchorTermNames[0].name;
+    }
+    else {
+      let termSetNames = props.termSetInfo.localizedNames.filter((name) => name.languageTag === props.languageTag);
+      if (termSetNames.length === 0) {
+        termSetNames = props.termSetInfo.localizedNames.filter((name) => name.languageTag === props.termStoreInfo.defaultLanguageTag);
+      }
+      termRootName = termSetNames[0].name;
+    }
+    const rootGroup: IGroup = {
+      name: termRootName,
+      key: props.anchorTermInfo ? props.anchorTermInfo.id : props.termSetInfo.id,
+      startIndex: -1,
+      count: 50,
+      level: 0,
+      isCollapsed: false,
+      data: { skiptoken: '' },
+      hasMoreData: (props.anchorTermInfo ? props.anchorTermInfo.childrenCount : props.termSetInfo.childrenCount) > 0
+    };
+    setGroups([rootGroup]);
+    setGroupsLoading((prevGroupsLoading) => [...prevGroupsLoading, props.termSetInfo.id]);
+    if (props.termSetInfo.childrenCount > 0) {
+      props.onLoadMoreData(Guid.parse(props.termSetInfo.id), props.anchorTermInfo ? Guid.parse(props.anchorTermInfo.id) : Guid.empty, '', true)
+        .then((loadedTerms) => {
+          const grps: IGroup[] = loadedTerms.value.map(term => {
+            let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
+            if (termNames.length === 0) {
+              termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.termStoreInfo.defaultLanguageTag && termLabel.isDefault === true));
+            }
+            const g: IGroup = {
+              name: termNames[0]?.name,
+              key: term.id,
+              startIndex: -1,
+              count: 50,
+              level: 1,
+              isCollapsed: true,
+              data: { skiptoken: '', term: term },
+              hasMoreData: term.childrenCount > 0,
+            };
+            if (g.hasMoreData) {
+              g.children = [];
+            }
+            return g;
+          });
+          props.setTerms((prevTerms) => {
+            const nonExistingTerms = loadedTerms.value.filter((term) => prevTerms.every((prevTerm) => prevTerm.id !== term.id));
+            return [...prevTerms, ...nonExistingTerms];
+          });
+          rootGroup.children = grps;
+          rootGroup.data.skiptoken = loadedTerms.skiptoken;
+          rootGroup.hasMoreData = loadedTerms.skiptoken !== '';
+          setGroupsLoading((prevGroupsLoading) => prevGroupsLoading.filter((value) => value !== props.termSetInfo.id));
+          setGroups([rootGroup]);
+        });
+    }
+  }, []);
+
+  const onToggleCollapse = (group: IGroup): void => {
+    if (group.isCollapsed === true) {
+      setGroups((prevGroups) => {
+        const recurseGroups = (currentGroup: IGroup) => {
+          if (currentGroup.key === group.key) {
+            currentGroup.isCollapsed = false;
+          }
+          if (currentGroup.children?.length > 0) {
+            for (const child of currentGroup.children) {
+              recurseGroups(child);
+            }
+          }
+        };
+        let newGroupsState: IGroup[] = [];
+        for (const prevGroup of prevGroups) {
+          recurseGroups(prevGroup);
+          newGroupsState.push(prevGroup);
+        }
+
+        return newGroupsState;
+      });
+
+      if (group.children && group.children.length === 0) {
+        setGroupsLoading((prevGroupsLoading) => [...prevGroupsLoading, group.key]);
+        group.data.isLoading = true;
+
+        props.onLoadMoreData(Guid.parse(props.termSetInfo.id), Guid.parse(group.key), '', true)
+          .then((loadedTerms) => {
+            const grps: IGroup[] = loadedTerms.value.map(term => {
+              let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
+              if (termNames.length === 0) {
+                termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.termStoreInfo.defaultLanguageTag && termLabel.isDefault === true));
+              }
+              const g: IGroup = {
+                name: termNames[0]?.name,
+                key: term.id,
+                startIndex: -1,
+                count: 50,
+                level: group.level + 1,
+                isCollapsed: true,
+                data: { skiptoken: '', term: term },
+                hasMoreData: term.childrenCount > 0,
+              };
+              if (g.hasMoreData) {
+                g.children = [];
+              }
+              return g;
+            });
+
+            props.setTerms((prevTerms) => {
+              const nonExistingTerms = loadedTerms.value.filter((term) => prevTerms.every((prevTerm) => prevTerm.id !== term.id));
+              return [...prevTerms, ...nonExistingTerms];
+            });
+
+            group.children = grps;
+            group.data.skiptoken = loadedTerms.skiptoken;
+            group.hasMoreData = loadedTerms.skiptoken !== '';
+            setGroupsLoading((prevGroupsLoading) => prevGroupsLoading.filter((value) => value !== group.key));
+          });
+      }
+    }
+    else {
+      setGroups((prevGroups) => {
+        const recurseGroups = (currentGroup: IGroup) => {
+          if (currentGroup.key === group.key) {
+            currentGroup.isCollapsed = true;
+          }
+          if (currentGroup.children?.length > 0) {
+            for (const child of currentGroup.children) {
+              recurseGroups(child);
+            }
+          }
+        };
+        let newGroupsState: IGroup[] = [];
+        for (const prevGroup of prevGroups) {
+          recurseGroups(prevGroup);
+          newGroupsState.push(prevGroup);
+        }
+
+        return newGroupsState;
+      });
+
+    }
+  };
+
+  const onRenderTitle = (groupHeaderProps: IGroupHeaderProps) => {
+    const isChildSelected = (children: IGroup[]): boolean => {
+      let aChildIsSelected = children && children.some((child) => props.selection.isKeySelected(child.key) || isChildSelected(child.children));
+      return aChildIsSelected;
+    };
+
+    const childIsSelected = props.selection && isChildSelected(groupHeaderProps.group.children);
+
+    if (groupHeaderProps.group.level === 0) {
+      const labelStyles: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles> = {root: {width: "100%", fontWeight: childIsSelected ? "bold" : "normal"}};
+      return (
+        <FocusZone
+          direction={FocusZoneDirection.horizontal}
+          className={styles.taxonomyItemFocusZone}
+        >
+          <Label styles={labelStyles}>{groupHeaderProps.group.name}</Label>
+          <div className={styles.actionButtonContainer}>
+            {props.onRenderActionButton && props.onRenderActionButton(props.termStoreInfo, props.termSetInfo, props.anchorTermInfo)}
+          </div>
+        </FocusZone>
+      );
+    }
+
+    if (!props.selection) {
+      const labelStyles: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles> = {root: {width: "100%", fontWeight: childIsSelected ? "bold" : "normal"}};
+      return (
+        <FocusZone
+          direction={FocusZoneDirection.horizontal}
+          className={styles.taxonomyItemFocusZone}
+        >
+          <Label styles={labelStyles}>{groupHeaderProps.group.name}</Label>
+          <div className={styles.actionButtonContainer}>
+            {props.onRenderActionButton && props.onRenderActionButton(props.termStoreInfo, props.termSetInfo, groupHeaderProps.group.data.term)}
+          </div>
+        </FocusZone>
+      );
+    }
+
+    const isDisabled = groupHeaderProps.group.data.term.isAvailableForTagging.filter((t) => t.setId === props.termSetInfo.id)[0].isAvailable === false;
+    const isSelected = props.selection.isKeySelected(groupHeaderProps.group.key);
+
+    if (props.allowMultipleSelections) {
+      const checkBoxStyles: IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles> = {root: { flex: "1" } };
+      if (isSelected || childIsSelected) {
+        checkBoxStyles.label = { fontWeight: 'bold' };
+      }
+      else {
+        checkBoxStyles.label = { fontWeight: 'normal' };
+      }
+
+      return (
+        <FocusZone
+          direction={FocusZoneDirection.horizontal}
+          className={styles.taxonomyItemFocusZone}
+        >
+          <Checkbox
+            key={groupHeaderProps.group.key}
+            label={groupHeaderProps.group.name}
+            checked={isSelected}
+            styles={checkBoxStyles}
+            disabled={isDisabled}
+            onRenderLabel={(p) => <span className={css(!isDisabled && styles.checkbox, isDisabled && styles.disabledCheckbox, isSelected && styles.selectedCheckbox)} title={p.title}>
+              {p.label}
+            </span>}
+            onChange={(ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
+              props.selection.setKeySelected(groupHeaderProps.group.key, checked, false);
+            }}
+          />
+          <div className={styles.actionButtonContainer}>
+            {props.onRenderActionButton && props.onRenderActionButton(props.termStoreInfo, props.termSetInfo, groupHeaderProps.group.data.term)}
+          </div>
+        </FocusZone>
+      );
+    }
+    else {
+      const choiceGroupOptionStyles: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles> = isSelected || childIsSelected ? { root: {marginTop: 0}, choiceFieldWrapper: { fontWeight: 'bold', flex: '1' }, field: { width: '100%'} } : { root: {marginTop: 0}, choiceFieldWrapper: { fontWeight: 'normal', flex: '1' }, field: { width: '100%'} };
+      const options: IChoiceGroupOption[] = [{
+                                                key: groupHeaderProps.group.key,
+                                                text: groupHeaderProps.group.name,
+                                                styles: choiceGroupOptionStyles,
+                                                onRenderLabel: (p) =>
+                                                  <span id={p.labelId} className={css(!isDisabled && styles.choiceOption, isDisabled && styles.disabledChoiceOption, isSelected && styles.selectedChoiceOption)}>
+                                                    {p.text}
+                                                  </span>,
+                                                onClick: () => {
+                                                  props.selection.setAllSelected(false);
+                                                  props.selection.setKeySelected(groupHeaderProps.group.key, true, false);
+                                                }
+                                              }];
+
+      const choiceGroupStyles: IStyleFunctionOrObject<IChoiceGroupStyleProps, IChoiceGroupStyles> = { root: { flex: "1" }, applicationRole: { width: "100%" } };
+
+      return (
+        <FocusZone
+          direction={FocusZoneDirection.horizontal}
+          className={styles.taxonomyItemFocusZone}
+        >
+            <ChoiceGroup
+              options={options}
+              selectedKey={props.selection.getSelection()[0]?.id}
+              disabled={isDisabled}
+              styles={choiceGroupStyles}
+            />
+          <div className={styles.actionButtonContainer}>
+            {props.onRenderActionButton && props.onRenderActionButton(props.termStoreInfo, props.termSetInfo, groupHeaderProps.group.data.term)}
+          </div>
+        </FocusZone>
+      );
+    }
+  };
+
+  const onRenderHeader = (headerProps: IGroupHeaderProps): JSX.Element => {
+    const groupHeaderStyles: IStyleFunctionOrObject<IGroupHeaderStyleProps, IGroupHeaderStyles> = {
+      expand: { height: 42, visibility: !headerProps.group.children || headerProps.group.level === 0 ? "hidden" : "visible", fontSize: 14 },
+      expandIsCollapsed: { visibility: !headerProps.group.children || headerProps.group.level === 0 ? "hidden" : "visible", fontSize: 14 },
+      check: { display: 'none' },
+      headerCount: { display: 'none' },
+      groupHeaderContainer: { height: 36, paddingTop: 3, paddingBottom: 3, paddingLeft: 3, paddingRight: 3, alignItems: 'center', },
+      root: { height: 42 },
+    };
+
+    const isDisabled = headerProps.group.data.term && headerProps.group.data.term.isAvailableForTagging.filter((t) => t.setId === props.termSetInfo.id)[0].isAvailable === false;
+
+    return (
+      <GroupHeader
+        {...headerProps}
+        styles={groupHeaderStyles}
+        className={styles.taxonomyItemHeader}
+        onRenderTitle={onRenderTitle}
+        onToggleCollapse={onToggleCollapse}
+        indentWidth={20}
+        expandButtonProps={{style: {color: props.themeVariant?.semanticColors.bodyText}}}
+        onGroupHeaderKeyUp={(ev: React.KeyboardEvent<HTMLElement>, group: IGroup) => {
+          if ((ev.key == " " || ev.key == "Enter" ) && !isDisabled) {
+            if (props.allowMultipleSelections) {
+              props.selection.toggleKeySelected(headerProps.group.key);
+            }
+            else {
+              props.selection.setAllSelected(false);
+              props.selection.setKeySelected(headerProps.group.key, true, false);
+            }
+          }
+        }}
+      />
+    );
+  };
+
+  const onRenderFooter = (footerProps: IGroupFooterProps): JSX.Element => {
+    if ((footerProps.group.hasMoreData || footerProps.group.children && footerProps.group.children.length === 0) && !footerProps.group.isCollapsed) {
+
+      if (groupsLoading.some(value => value === footerProps.group.key)) {
+        const spinnerStyles: IStyleFunctionOrObject<ISpinnerStyleProps, ISpinnerStyles> = { circle: { verticalAlign: 'middle' } };
+        return (
+          <div className={styles.spinnerContainer}>
+            <Spinner styles={spinnerStyles} />
+          </div>
+        );
+      }
+      const linkStyles: IStyleFunctionOrObject<ILinkStyleProps, ILinkStyles> = { root: { fontSize: '14px', paddingLeft: (footerProps.groupLevel + 1) * 20 + 62 } };
+      return (
+        <div className={styles.loadMoreContainer}>
+          <Link onClick={() => {
+            setGroupsLoading((prevGroupsLoading) => [...prevGroupsLoading, footerProps.group.key]);
+            props.onLoadMoreData(Guid.parse(props.termSetInfo.id), footerProps.group.key === props.termSetInfo.id ? Guid.empty : Guid.parse(footerProps.group.key), footerProps.group.data.skiptoken, true)
+              .then((loadedTerms) => {
+                const grps: IGroup[] = loadedTerms.value.map(term => {
+                  let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
+                  if (termNames.length === 0) {
+                    termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.termStoreInfo.defaultLanguageTag && termLabel.isDefault === true));
+                  }
+                  const g: IGroup = {
+                    name: termNames[0]?.name,
+                    key: term.id,
+                    startIndex: -1,
+                    count: 50,
+                    level: footerProps.group.level + 1,
+                    isCollapsed: true,
+                    data: { skiptoken: '', term: term },
+                    hasMoreData: term.childrenCount > 0,
+                  };
+                  if (g.hasMoreData) {
+                    g.children = [];
+                  }
+                  return g;
+                });
+                props.setTerms((prevTerms) => {
+                  const nonExistingTerms = loadedTerms.value.filter((term) => prevTerms.every((prevTerm) => prevTerm.id !== term.id));
+                  return [...prevTerms, ...nonExistingTerms];
+                });
+                footerProps.group.children = [...footerProps.group.children, ...grps];
+                footerProps.group.data.skiptoken = loadedTerms.skiptoken;
+                footerProps.group.hasMoreData = loadedTerms.skiptoken !== '';
+                setGroupsLoading((prevGroupsLoading) => prevGroupsLoading.filter((value) => value !== footerProps.group.key));
+              });
+          }}
+            styles={linkStyles}>
+            {strings.ModernTaxonomyPickerLoadMoreText}
+          </Link>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const onRenderShowAll: IRenderFunction<IGroupShowAllProps> = () => {
+    return null;
+  };
+
+  const groupProps: IGroupRenderProps = {
+    onRenderFooter: onRenderFooter,
+    onRenderHeader: onRenderHeader,
+    showEmptyGroups: true,
+    onRenderShowAll: onRenderShowAll,
+  };
+
+  const shouldEnterInnerZone = (ev: React.KeyboardEvent<HTMLElement>): boolean => {
+    return ev.which === getRTLSafeKeyCode(KeyCodes.right);
+  };
+
+  return (
+    <div>
+      <GroupedList
+        items={[]}
+        onRenderCell={null}
+        groups={groups}
+        groupProps={groupProps}
+        onShouldVirtualize={(p: IListProps<any>) => false}
+        data-is-focusable={true}
+        focusZoneProps={{direction: FocusZoneDirection.vertical, shouldEnterInnerZone: shouldEnterInnerZone}}
+      />
+    </div>
+  );
+}

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
@@ -4,6 +4,7 @@ import { Checkbox,
          css,
          FocusZone,
          FocusZoneDirection,
+         FontIcon,
          getRTLSafeKeyCode,
          GroupedList,
          GroupHeader,
@@ -55,6 +56,8 @@ export interface ITaxonomyTreeProps {
   terms: ITermInfo[];
   setTerms: React.Dispatch<React.SetStateAction<ITermInfo[]>>;
   selection?: Selection<any>;
+  hideDeprecatedTerms?: boolean;
+  showIcons?: boolean;
 }
 
 export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITaxonomyTreeProps> {
@@ -90,7 +93,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
     setGroups([rootGroup]);
     setGroupsLoading((prevGroupsLoading) => [...prevGroupsLoading, props.termSetInfo.id]);
     if (props.termSetInfo.childrenCount > 0) {
-      props.onLoadMoreData(Guid.parse(props.termSetInfo.id), props.anchorTermInfo ? Guid.parse(props.anchorTermInfo.id) : Guid.empty, '', true)
+      props.onLoadMoreData(Guid.parse(props.termSetInfo.id), props.anchorTermInfo ? Guid.parse(props.anchorTermInfo.id) : Guid.empty, '', props.hideDeprecatedTerms)
         .then((loadedTerms) => {
           const grps: IGroup[] = loadedTerms.value.map(term => {
             let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
@@ -151,7 +154,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
         setGroupsLoading((prevGroupsLoading) => [...prevGroupsLoading, group.key]);
         group.data.isLoading = true;
 
-        props.onLoadMoreData(Guid.parse(props.termSetInfo.id), Guid.parse(group.key), '', true)
+        props.onLoadMoreData(Guid.parse(props.termSetInfo.id), Guid.parse(group.key), '', props.hideDeprecatedTerms)
           .then((loadedTerms) => {
             const grps: IGroup[] = loadedTerms.value.map(term => {
               let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));
@@ -225,6 +228,9 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
           direction={FocusZoneDirection.horizontal}
           className={styles.taxonomyItemFocusZone}
         >
+          {props.showIcons && (
+            <FontIcon iconName="Tag"  className={styles.taxonomyItemIcon} />
+          )}
           <Label styles={labelStyles}>{groupHeaderProps.group.name}</Label>
           <div className={styles.actionButtonContainer}>
             {props.onRenderActionButton && props.onRenderActionButton(props.termStoreInfo, props.termSetInfo, props.anchorTermInfo)}
@@ -235,11 +241,15 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
 
     if (!props.selection) {
       const labelStyles: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles> = {root: {width: "100%", fontWeight: childIsSelected ? "bold" : "normal"}};
+      let taxonomyItemIconName: string = groupHeaderProps.group.data.term.isDeprecated ? "Blocked" : "Tag";
       return (
         <FocusZone
           direction={FocusZoneDirection.horizontal}
           className={styles.taxonomyItemFocusZone}
         >
+          {props.showIcons && (
+            <FontIcon iconName={taxonomyItemIconName} className={styles.taxonomyItemIcon} />
+          )}
           <Label styles={labelStyles}>{groupHeaderProps.group.name}</Label>
           <div className={styles.actionButtonContainer}>
             {props.onRenderActionButton && props.onRenderActionButton(props.termStoreInfo, props.termSetInfo, groupHeaderProps.group.data.term)}
@@ -373,7 +383,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
         <div className={styles.loadMoreContainer}>
           <Link onClick={() => {
             setGroupsLoading((prevGroupsLoading) => [...prevGroupsLoading, footerProps.group.key]);
-            props.onLoadMoreData(Guid.parse(props.termSetInfo.id), footerProps.group.key === props.termSetInfo.id ? Guid.empty : Guid.parse(footerProps.group.key), footerProps.group.data.skiptoken, true)
+            props.onLoadMoreData(Guid.parse(props.termSetInfo.id), footerProps.group.key === props.termSetInfo.id ? Guid.empty : Guid.parse(footerProps.group.key), footerProps.group.data.skiptoken, props.hideDeprecatedTerms)
               .then((loadedTerms) => {
                 const grps: IGroup[] = loadedTerms.value.map(term => {
                   let termNames = term.labels.filter((termLabel) => (termLabel.languageTag === props.languageTag && termLabel.isDefault === true));

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
@@ -103,11 +103,11 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
       }
       groupToAddTermTo.children = [...groupToAddTermTo.children ?? [], g];
       props.setTerms((prevTerms) => {
-        const nonExistingTerms = newTermItems.filter((term) => prevTerms.every((prevTerm) => prevTerm.id !== term.id));
+        const nonExistingTerms = newTermItems.filter((newTerm) => prevTerms.every((prevTerm) => prevTerm.id !== newTerm.id));
         return [...prevTerms, ...nonExistingTerms];
       });
     }
-  }
+  };
 
   const updateTaxonomyTreeViewWithUpdatedTermItems = (updatedTermItems: ITermInfo[]): void => {
     for (const term of updatedTermItems) {
@@ -143,7 +143,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
         return [...prevTerms.filter(t => t.id !== term.id), term];
       });
     }
-  }
+  };
 
   const updateTaxonomyTreeViewWithDeletedTermItems = (deletedTermItems: ITermInfo[]): void => {
     for (const term of deletedTermItems) {
@@ -168,7 +168,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
         return [...prevTerms.filter(t => t.id !== term.id)];
       });
     }
-  }
+  };
 
   const updateTaxonomyTreeView = (newTermItems?: ITermInfo[], updatedTermItems?: ITermInfo[], deletedTermItems?: ITermInfo[]): void => {
     if (newTermItems) {
@@ -182,7 +182,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
     if (deletedTermItems) {
       updateTaxonomyTreeViewWithDeletedTermItems(deletedTermItems);
     }
-  }
+  };
 
   React.useEffect(() => {
     let termRootName = "";
@@ -405,7 +405,9 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
               {p.label}
             </span>}
             onChange={(ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
-              props.selection && props.selection.setKeySelected(groupHeaderProps.group.key, checked, false);
+              if (props.selection) {
+                props.selection.setKeySelected(groupHeaderProps.group.key, checked, false);
+              }
             }}
           />
           <div className={styles.actionButtonContainer}>
@@ -425,8 +427,10 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
                                                     {p.text}
                                                   </span>,
                                                 onClick: () => {
-                                                  props.selection && props.selection.setAllSelected(false);
-                                                  props.selection && props.selection.setKeySelected(groupHeaderProps.group.key, true, false);
+                                                  if (props.selection) {
+                                                    props.selection.setAllSelected(false);
+                                                    props.selection.setKeySelected(groupHeaderProps.group.key, true, false);
+                                                  }
                                                 }
                                               }];
 
@@ -475,11 +479,15 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
         onGroupHeaderKeyUp={(ev: React.KeyboardEvent<HTMLElement>, group: IGroup) => {
           if ((ev.key == " " || ev.key == "Enter" ) && !isDisabled) {
             if (props.allowMultipleSelections) {
-              props.selection && props.selection.toggleKeySelected(headerProps.group.key);
+              if (props.selection) {
+                props.selection.toggleKeySelected(headerProps.group.key);
+              }
             }
             else {
-              props.selection && props.selection.setAllSelected(false);
-              props.selection && props.selection.setKeySelected(headerProps.group.key, true, false);
+              if (props.selection) {
+                props.selection.setAllSelected(false);
+                props.selection.setKeySelected(headerProps.group.key, true, false);
+              }
             }
           }
         }}

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/index.ts
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/index.ts
@@ -1,0 +1,1 @@
+export * from './TaxonomyTree';

--- a/src/controls/modernTaxonomyPicker/termItem/index.ts
+++ b/src/controls/modernTaxonomyPicker/termItem/index.ts
@@ -1,0 +1,2 @@
+export * from './TermItem';
+export * from './TermItemSuggestion';

--- a/src/webparts/controlsTest/ControlsTestWebPart.ts
+++ b/src/webparts/controlsTest/ControlsTestWebPart.ts
@@ -79,7 +79,7 @@ export default class ControlsTestWebPart extends BaseClientSideWebPart<IControls
 
    const element: React.ReactElement<IControlsTestProps> = React.createElement(
 
-     ControlsTest,
+     ControlsTest_SingleComponent,
       {
 
         themeVariant: this._themeVariant,

--- a/src/webparts/controlsTest/components/IControlsTestProps.ts
+++ b/src/webparts/controlsTest/components/IControlsTestProps.ts
@@ -8,6 +8,7 @@ import {
   IReadonlyTheme,
 
 } from "@microsoft/sp-component-base";
+import { ITermInfo } from '@pnp/sp/taxonomy';
 export interface IControlsTestProps {
   context: WebPartContext;
   description: string;
@@ -45,4 +46,7 @@ export interface IControlsTestState {
   selectedTeamChannels:ITag[];
   filePickerDefaultFolderAbsolutePath?: string;
   errorMessage?: string;
+  termPanelIsOpen?: boolean;
+  actionTermId?: string;
+  clickedActionTerm?: ITermInfo;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | 

#### What's in this Pull Request?
Added a feature to ModernTaxonomyPicker to add a custom action button to each term in the term set and the term set itself.
This also comes with the added bonus of better handling of keyboard navigation.
Added properties isLightDismiss and isBlocking that will be used for the panel.
Refactored TaxonomyTree into a separate component that could be used separately to just display a term set with action buttons for e.g. an admin UI.

Here is an example of what it could look like with a context menu for adding and deleting terms in the control:

![image](https://user-images.githubusercontent.com/31273837/141211973-15bfc75e-c149-4b80-9558-6ed37eb51bc0.png)
