### PR TITLE
Parsing DynamicForm defaultValue for Boolean fields - Fix for #1073

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -441,6 +441,9 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
         else if (fieldType === "Location") {
           defaultValue = JSON.parse(defaultValue);
         }
+        else if (fieldType === "Boolean") {
+          defaultValue = Boolean(Number(defaultValue));
+        }
 
         tempFields.push({
           newValue: null,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [*]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1073

#### What's in this Pull Request?

Lines 444-446 of DynamicForm.tsx parse the string-based defaultValue, converting it to a Boolean. This fixes an issue whereby the DynamicForm control wasn't honouring the default value setting in list fields when presenting a 'New' form. See #1073