### PR TITLE
Modified regional format of dates as implemented in DynamicField.tsx - Fix for #1075

### DIFF
--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -299,7 +299,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
             <DatePicker
               placeholder={placeholder}
               className={styles.pickersContainer}
-              formatDate={(date) => { return date.toLocaleDateString(context.pageContext.web.languageName); }}
+              formatDate={(date) => { return date.toLocaleDateString(context.pageContext.cultureInfo.currentCultureName); }}
               value={(changedValue !== null && changedValue !== "") ? changedValue : defaultValue}
               onSelectDate={(newDate) => { this.onChange(newDate); }}
               disabled={disabled}
@@ -309,7 +309,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
             <DateTimePicker
               key={columnInternalName}
               placeholder={placeholder}
-              formatDate={(date) => { return date.toLocaleDateString(context.pageContext.web.languageName); }}
+              formatDate={(date) => { return date.toLocaleDateString(context.pageContext.cultureInfo.currentCultureName); }}
               value={(changedValue !== null && changedValue !== "") ? changedValue : defaultValue}
               onChange={(newDate) => { this.onChange(newDate); }}
               disabled={disabled} />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ *]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1075

#### What's in this Pull Request?

[DynamicField.tsx](https://github.com/pnp/sp-dev-fx-controls-react/blob/master/src/controls/dynamicForm/dynamicField/DynamicField.tsx) has been amended on Lines 302 and 312 - swapping `context.pageContext.web.languageName` with `context.pageContext.cultureInfo.currentCultureName`. This fixes an issue with DynamicForm not displaying dates correctly when the region is changed (for example to en-GB) in regional settings - #1075