### PR TITLE
Amend DynamicForm.tsx to use EntityPropertyName rather than InternalName - Fix for #1077

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -323,7 +323,7 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
         let dateFormat: DateFormat | undefined;
         let principalType = "";
         if (item !== null) {
-          defaultValue = item[field.InternalName];
+          defaultValue = item[field.EntityPropertyName];
         }
         else {
           defaultValue = field.DefaultValue;
@@ -455,7 +455,7 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
           context: this.props.context,
           disabled: this.props.disabled || (disabledFields && disabledFields.indexOf(field.InternalName) > -1),
           listId: this.props.listId,
-          columnInternalName: field.InternalName,
+          columnInternalName: field.EntityPropertyName,
           label: field.Title,
           onChanged: this.onChange,
           required: field.Required,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [*]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1077

#### What's in this Pull Request?

Fixes an issue where the DynamicForm control would not load or save field values correctly if field(s) were created with special characters at the start of their display name i.e. "% Complete"

Amends DynamicForm.tsx to swap `field.InternalName` references for `field.EntityPropertyName` - which better reflects what the SharePoint API expects as property names. See #1077 for details.