### PR TITLE
Added allowTextInput property

### DIFF
--- a/docs/documentation/docs/controls/DateTimePicker.md
+++ b/docs/documentation/docs/controls/DateTimePicker.md
@@ -62,6 +62,7 @@ The `DateTimePicker` control can be configured with the following properties:
 | isMonthPickerVisible | boolean | no | Controls whether the month picker is shown beside the day picker or hidden. |
 | showMonthPickerAsOverlay | boolean | no | Show month picker on top of date picker when visible. |
 | showWeekNumbers | boolean | no | Controls whether the calendar should show the week number (weeks 1 to 53) before each week row |
+| allowTextInput | boolean | no | Whether the user is allowed to enter a date instead of picking one from the date picker. |
 | strings | IDatePickerStrings | no | Localized strings to use in the DateTimePicker |
 | value | Date | no | Default value of the DatePicker, if any |
 | onChange | function | no | Callback issued when date or time is changed |

--- a/docs/documentation/docs/controls/DateTimePicker.md
+++ b/docs/documentation/docs/controls/DateTimePicker.md
@@ -62,7 +62,7 @@ The `DateTimePicker` control can be configured with the following properties:
 | isMonthPickerVisible | boolean | no | Controls whether the month picker is shown beside the day picker or hidden. |
 | showMonthPickerAsOverlay | boolean | no | Show month picker on top of date picker when visible. |
 | showWeekNumbers | boolean | no | Controls whether the calendar should show the week number (weeks 1 to 53) before each week row |
-| allowTextInput | boolean | no | Whether the user is allowed to enter a date instead of picking one from the date picker. |
+| allowTextInput | boolean | no | Whether the user is allowed to enter a date as text instead of picking one from the date picker. |
 | strings | IDatePickerStrings | no | Localized strings to use in the DateTimePicker |
 | value | Date | no | Default value of the DatePicker, if any |
 | onChange | function | no | Callback issued when date or time is changed |

--- a/src/controls/dateTimePicker/DateTimePicker.tsx
+++ b/src/controls/dateTimePicker/DateTimePicker.tsx
@@ -213,6 +213,7 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
       firstDayOfWeek,
       isMonthPickerVisible = true,
       showGoToToday,
+      allowTextInput = false,
       showMonthPickerAsOverlay = false,
       showWeekNumbers = false,
       showSeconds = false,
@@ -308,7 +309,7 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
                 strings={dateStrings}
                 isMonthPickerVisible={isMonthPickerVisible}
                 onSelectDate={this.onSelectDate}
-                allowTextInput={true}
+                allowTextInput={allowTextInput}
                 firstDayOfWeek={firstDayOfWeek}
                 showGoToToday={showGoToToday}
                 showMonthPickerAsOverlay={showMonthPickerAsOverlay}

--- a/src/controls/dateTimePicker/DateTimePicker.tsx
+++ b/src/controls/dateTimePicker/DateTimePicker.tsx
@@ -213,7 +213,7 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
       firstDayOfWeek,
       isMonthPickerVisible = true,
       showGoToToday,
-      allowTextInput = false,
+      allowTextInput = true,
       showMonthPickerAsOverlay = false,
       showWeekNumbers = false,
       showSeconds = false,

--- a/src/controls/dateTimePicker/IDateTimePickerProps.ts
+++ b/src/controls/dateTimePicker/IDateTimePickerProps.ts
@@ -60,6 +60,11 @@ export interface IDateTimePickerProps {
    */
   deferredValidationTime?: number;
   /**
+   * Whether the user is allowed to enter a date instead of picking one from the date picker.
+   * @defaultvalue false
+   */
+  allowTextInput?: boolean;
+  /**
    * Whether the "Go to today" link should be shown or not
    */
   showGoToToday?: boolean;

--- a/src/controls/dateTimePicker/IDateTimePickerProps.ts
+++ b/src/controls/dateTimePicker/IDateTimePickerProps.ts
@@ -60,7 +60,7 @@ export interface IDateTimePickerProps {
    */
   deferredValidationTime?: number;
   /**
-   * Whether the user is allowed to enter a date instead of picking one from the date picker.
+   * Whether the user is allowed to enter a date as text instead of picking one from the date picker.
    * @defaultvalue false
    */
   allowTextInput?: boolean;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ x ]
| New sample?      | [ ]
| Related issues?  | fixes [#1094](https://github.com/pnp/sp-dev-fx-controls-react/issues/1094)

#### What's in this Pull Request?

Exposed the allowTextInput property. Developer can now choose whether the user can add dates as text value rather than picking one from the date picker.
