### PR TITLE
Adds aria-label options for Carousel buttons

### DIFF
--- a/src/controls/carousel/Carousel.tsx
+++ b/src/controls/carousel/Carousel.tsx
@@ -66,6 +66,8 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
       loadingComponentContainerStyles,
       prevButtonIconName = 'ChevronLeft',
       nextButtonIconName = 'ChevronRight',
+      prevButtonAriaLabel = 'Previous item',
+      nextButtonAriaLabel = 'Next item',
       loadingComponent = <Spinner />,
       pauseOnHover,
       interval,
@@ -88,7 +90,7 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
             onClick={() => { if (!prevButtonDisabled) { this.onCarouselButtonClicked(false); } }} >
             <IconButton
               className={this.getMergedStyles(this.getButtonStyles(false), prevButtonStyles)}
-              iconProps={{ iconName: prevButtonIconName }}
+              iconProps={{ iconName: prevButtonIconName, ariaLabel: prevButtonAriaLabel }}
               disabled={prevButtonDisabled}
               onClick={() => { this.onCarouselButtonClicked(false); }} />
           </div>
@@ -115,7 +117,7 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
             onClick={() => { if (!nextButtonDisabled) { this.onCarouselButtonClicked(true); } }}>
             <IconButton
               className={this.getMergedStyles(this.getButtonStyles(true), nextButtonStyles)}
-              iconProps={{ iconName: nextButtonIconName }}
+              iconProps={{ iconName: nextButtonIconName, ariaLabel: nextButtonAriaLabel }}
               disabled={nextButtonDisabled}
               onClick={() => { this.onCarouselButtonClicked(true); }} />
           </div>

--- a/src/controls/carousel/ICarouselProps.ts
+++ b/src/controls/carousel/ICarouselProps.ts
@@ -123,6 +123,15 @@ export interface ICarouselProps {
    */
   nextButtonIconName?: string;
   /**
+   * Aria label of the PreviousItem button. Default 'Previous item'.
+   */
+  prevButtonAriaLabel?: string;
+
+  /**
+   * Aria label of the NextItem button. Default 'Next item'.
+   */
+  nextButtonAriaLabel?: string;
+  /**
    * Triggers parent control to provide new element to be displayed. After the method is executed, carousel control switches to processing mode and loadingComponent is displayed.
    */
   triggerPageEvent?: (index: number) => void;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1137 

#### What's in this Pull Request?

Allows consumers to pass aria-label for Carousel's prev and next item buttons 

