### PR TITLE
Fix: sorting the terms in locale language

### DIFF
--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -531,10 +531,10 @@ export default class SPTermStorePickerService {
    */
   private sortTermByPath(a: ITerm, b: ITerm) {
     if (a.CustomSortOrderIndex === -1) {
-      if (a.PathOfTerm.toLowerCase() < b.PathOfTerm.toLowerCase()) {
+      if (a.Name.toLowerCase() < b.Name.toLowerCase()) {
         return -1;
       }
-      if (a.PathOfTerm.toLowerCase() > b.PathOfTerm.toLowerCase()) {
+      if (a.Name.toLowerCase() > b.Name.toLowerCase()) {
         return 1;
       }
       return 0;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

This PR fixes an issue with terms not getting sorted when used in language specific browser with labels.
It always follows the default order of term store.

To repro this bug:

Create a term set with some terms. 
In the term store, ensure that you have atleast one other language available for use.
Add the label values in the other language.

It will always fetch the order of the default language