### PR TITLE
Trigger onChange on picker clear action

### DIFF
--- a/src/controls/locationPicker/LocationPicker.tsx
+++ b/src/controls/locationPicker/LocationPicker.tsx
@@ -214,6 +214,9 @@ export class LocationPicker extends React.Component<ILocationPickerProps, ILocat
 
   private onIconButtonClick = () => {
     this.setState({ currentMode: Mode.empty, selectedItem: null });
+    if (this.props.onChange) {
+      this.props.onChange(null);
+    }
   }
 
   private onClick = () => {


### PR DESCRIPTION
In the current release, the onChange event is not triggered when the selected item is reset to null (Clear button).

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | mentioned in #1125

#### What's in this Pull Request?

Trigger the onChange event handler when the clear button is clicked and selected item reset to null.