### PR TITLE
people picker transitive members

### DIFF
--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -195,9 +195,9 @@ export default class SPPeopleSearchService {
         searchBody.queryParams["SharePointGroupID"] = groupId;
       }
 
-      // Check if users need to be searched in a specific Office365 Group
+      // Check if users need to be searched in a specific Microsoft 365 Group, Security Group (incl. nested groups) or Distribution List
       else if(groupId && typeof(groupId) === 'string') {
-        const graphUserRequestUrl = `/groups/${groupId}/members?$count=true&$search="displayName:${query}" OR "mail:${query}"`;
+        const graphUserRequestUrl = `/groups/${groupId}/transitiveMembers?$count=true&$search="displayName:${query}" OR "mail:${query}"`;
         const graphClient = await this.context.msGraphClientFactory.getClient();
         const graphUserResponse = await graphClient.api(graphUserRequestUrl).header('ConsistencyLevel', 'eventual').get();
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #1173

#### What's in this Pull Request?

When groupId-string is provided now fetches also transitive members in case an id of a security group is provided. Previously only direct members of the security group were fetched.


