### PR TITLE
Fixing TreeView nodes to expand and selection issues

### DIFF
--- a/src/controls/treeView/TreeItem.tsx
+++ b/src/controls/treeView/TreeItem.tsx
@@ -160,10 +160,8 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
       let active = nextProps.activeItems.filter(item => item.key === treeItem.key);
 
       let _isExpanded:boolean=this.state.expanded;
-      if(!_isExpanded &&  nodesToExpand?.indexOf(this.props.treeItem.key) != -1) {
-        _isExpanded = true;
-      }
-      if(_isExpanded && nodesToExpand?.indexOf(this.props.treeItem.key) == -1){
+      
+      if(!_isExpanded && nodesToExpand.indexOf(this.props.treeItem.key) == -1){
         _isExpanded=false;
       }
 

--- a/src/controls/treeView/TreeView.tsx
+++ b/src/controls/treeView/TreeView.tsx
@@ -43,14 +43,16 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
     let result: string;
     if (array) {
       array.some(({ key, children = [] }) => {
+        const alreadyExistInNodesToExpand = this.nodesToExpand.some((node) => node === key);
+
         if (key === target) {
-          this.nodesToExpand.push(key);
+          !alreadyExistInNodesToExpand && this.nodesToExpand.push(key);
           result = key;
           return true;
         }
         let temp = this.pathTo(children, target);
         if (temp) {
-          this.nodesToExpand.push(key);
+          !alreadyExistInNodesToExpand && this.nodesToExpand.push(key);
           result = key + '.' + temp;
           return true;
         }
@@ -90,6 +92,12 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
    * @argument isExpanded The status of item  (expanded / collapsed)
    */
   private handleTreeExpandCollapse(item: ITreeItem, isExpanded: boolean): void {
+    if (isExpanded) {
+      this.nodesToExpand.push(item.key);
+    } else {
+      this.nodesToExpand = this.nodesToExpand.filter((node) => node !== item.key);
+    }
+
     if (typeof this.props.onExpandCollapse === "function") {
       this.props.onExpandCollapse(item, isExpanded);
     }
@@ -240,8 +248,8 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
       showCheckboxes,
       treeItemActionsDisplayMode,
       defaultExpanded,
-      defaultExpandedChildren,
-      defaultExpandedKeys
+      defaultExpandedChildren = this.props.defaultExpandedChildren ?? true,
+      defaultExpandedKeys = this.props.defaultExpandedKeys ?? [],
     } = this.props;
 
     return (
@@ -253,7 +261,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
               leftOffset={20}
               isFirstRender={true}
               defaultExpanded={defaultExpanded}
-              defaultExpandedChildren={defaultExpandedChildren !== undefined ? defaultExpandedChildren : true}
+              defaultExpandedChildren={defaultExpandedChildren}
               selectionMode={selectionMode}
               activeItems={this.state.activeItems}
               parentCallbackExpandCollapse={this.handleTreeExpandCollapse}
@@ -261,7 +269,7 @@ export class TreeView extends React.Component<ITreeViewProps, ITreeViewState> {
               onRenderItem={onRenderItem}
               showCheckboxes={showCheckboxes}
               treeItemActionsDisplayMode={treeItemActionsDisplayMode}
-              nodesToExpand={defaultExpandedKeys}
+              nodesToExpand={[...this.nodesToExpand, ...defaultExpandedKeys]}
             />
           ))
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1182 #1170 #1062

#### What's in this Pull Request?

- nodesToExpand from TreeItem now takes nodesToExpand + defaultExpandedKeys instead of just defaultExpandendKeys
![image](https://user-images.githubusercontent.com/24293827/162242607-2898550b-ee22-4856-8751-c45f2d6b97c3.png)
- handleTreeExpandCollapse now updating nodesToExpand content
- pathTo function from TreeView wont add duplicates to nodesToExpand
- When populating children on first expand wont open all closed section containing selected childrens
![image](https://user-images.githubusercontent.com/24293827/162244668-d2f615cc-4c66-4c10-aae8-dbb72d9679bb.png)


You can ignore the other participant for this PR. JoelM365 is my second account. Joel Lopes is my main account.

I'm available if you have any questions.
Have a nice day.
Joel