### PR TITLE
"spfx-uifabric-themes" to "^0.9.0" to fix #1187

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-mentions": "^4.3.0",
     "react-quill": "1.3.5",
     "regexify-string": "^1.0.16",
-    "spfx-uifabric-themes": "^0.8.5"
+    "spfx-uifabric-themes": "^0.9.0"
   },
   "devDependencies": {
     "@microsoft/microsoft-graph-types": "^2.1.0",


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1187 

#### What's in this Pull Request?

Bumping "spfx-uifabric-themes" to "^0.9.0".  "spfx-uifabric-themes" @ "^0.9.0" removes dependencies that are not needed and that were causing npm audit with critical failure for https://github.com/advisories/GHSA-xvch-5gv4-984h.
