### PR TITLE
Fixed localization typo

### DIFF
--- a/src/loc/nl-nl.ts
+++ b/src/loc/nl-nl.ts
@@ -2,7 +2,7 @@ declare var define: any;
 
 define([], () => {
   return {
-  "Save": "Redden",
+  "Save": "Opslaan",
   "Cancel": "Annuleren",
   "SiteBreadcrumbLabel": "Website broodkruimelpad",
   "ListViewGroupEmptyLabel": "Leeg",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | None

#### What's in this Pull Request?

Fixed dutch localization typo.
'Redden' in dutch is used in the context "to **save** someone".
'Opslaan' in dutch is used in the context "to **save** a file".