### PR TITLE
fix bugs: cannot get lookup value when lookup source field is not def…

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -340,7 +340,7 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
           lookupListId = field["LookupList"];
           lookupField = field["LookupField"];
           if (item !== null) {
-            defaultValue = await this._spService.getLookupValue(listId, listItemId, field.InternalName, context.pageContext.web.absoluteUrl);
+            defaultValue = await this._spService.getLookupValue(listId, listItemId, field.InternalName, lookupField, context.pageContext.web.absoluteUrl);
           }
           else {
             defaultValue = [];
@@ -351,7 +351,7 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
           lookupListId = field["LookupList"];
           lookupField = field["LookupField"];
           if (item !== null) {
-            defaultValue = await this._spService.getLookupValues(listId, listItemId, field.InternalName, context.pageContext.web.absoluteUrl);
+            defaultValue = await this._spService.getLookupValues(listId, listItemId, field.InternalName, lookupField, context.pageContext.web.absoluteUrl);
           }
           else {
             defaultValue = [];

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -386,10 +386,11 @@ export default class SPService implements ISPService {
     return;
   }
 
-  public async getLookupValue(listId: string, listItemID: number, fieldName: string, webUrl?: string): Promise<any[]> {
+  public async getLookupValue(listId: string, listItemID: number, fieldName: string, lookupField?: string, webUrl?: string): Promise<any[]> {
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      let apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})/?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/Title&$expand=${fieldName}`;
+      let apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})/?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/${
+      lookupField||'Title'}&$expand=${fieldName}`;
 
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {
@@ -406,10 +407,10 @@ export default class SPService implements ISPService {
     }
   }
 
-  public async getLookupValues(listId: string, listItemID: number, fieldName: string, webUrl?: string): Promise<any[]> {
+  public async getLookupValues(listId: string, listItemID: number, fieldName: string, lookupField?: string, webUrl?: string): Promise<any[]> {
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      let apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/Title&$expand=${fieldName}`;
+      let apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/${lookupField||'Title'}&$expand=${fieldName}`;
 
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {


### PR DESCRIPTION
…ault Title field

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Fix bug: [#1215 ](https://github.com/pnp/sp-dev-fx-controls-react/issues/1215)
DynamicForm cannot display lookup value when the lookup source field is not **Title**. The SPService class loading lookup value always expand `lookupField/Title`. 


#### Guidance
- *You can delete this section when you are submitting the pull request.* 
- *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
- *Please target your PR to **dev** branch.*
