### PR TITLE
DateTimePicker - clear date

### DIFF
--- a/docs/documentation/docs/controls/DateTimePicker.md
+++ b/docs/documentation/docs/controls/DateTimePicker.md
@@ -73,6 +73,8 @@ The `DateTimePicker` control can be configured with the following properties:
 | maxDate | Date | no | The maximum allowable date. |
 | minDate | Date | no | The minimum allowable date. |
 | minutesIncrementStep | MinutesIncrement | no | Specifies minutes' increment step for `TimeDisplayControlType.Dropdow` |
+| showClearDate | boolean | no | Controls whether the clearDate iconbutton must be available when date is selected, default to false
+| showClearDateIcon | string | no | Controls the icon used for clearDate iconbutton. Defaults to 'RemoveEvent'
 
 Enum `TimeDisplayControlType`
 

--- a/src/controls/dateTimePicker/DateTimePicker.tsx
+++ b/src/controls/dateTimePicker/DateTimePicker.tsx
@@ -3,6 +3,7 @@ import { isEqual } from '@microsoft/sp-lodash-subset';
 import { TimeConvention, DateConvention } from "./DateTimeConventions";
 import { DatePicker } from "office-ui-fabric-react/lib/DatePicker";
 import { Label } from "office-ui-fabric-react/lib/Label";
+import { IconButton } from "office-ui-fabric-react/lib/Button";
 import ErrorMessage from "../errorMessage/ErrorMessage";
 import styles from "./DateTimePicker.module.scss";
 import HoursComponent from "./HoursComponent";
@@ -97,9 +98,11 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
    * Function called when the DatePicker Office UI Fabric component selected date changed
    */
   private onSelectDate = (date: Date): void => {
+
     if (!TimeHelper.isValidDate(date)) {
       return;
     }
+
     // Get hours, minutes and seconds from state or default to zero
     const { hours = 0, minutes = 0, seconds = 0 } = this.state;
     const day = TimeHelper.cloneDate(date);
@@ -109,7 +112,14 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
     this.setState({ day }, () => this.delayedValidate(this.state.day));
   }
 
-
+  /**
+   * Function called from the clearDate iconbutton
+   */
+  private clearDate() {
+    this.setState({
+      day: null
+    });
+  }
 
   /**
    * Function called when hours value have been changed
@@ -225,7 +235,9 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
       showLabels,
       minDate,
       maxDate,
-      minutesIncrementStep
+      minutesIncrementStep,
+      showClearDate = false,
+      showClearDateIcon= 'RemoveEvent'
     } = this.props;
 
     const { textErrorMessage } = dateStrings;
@@ -322,6 +334,8 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
                 }}
               />
             </div>
+            {showClearDate === true && this.state.day !==null ? <IconButton iconProps={{iconName: showClearDateIcon}} onClick={() => this.clearDate()} /> : <></>}
+            
           </div>
 
           {timeElm}

--- a/src/controls/dateTimePicker/IDateTimePickerProps.ts
+++ b/src/controls/dateTimePicker/IDateTimePickerProps.ts
@@ -131,4 +131,14 @@ export interface IDateTimePickerProps {
    * Specifies minutes' increment step
    */
   minutesIncrementStep?: MinutesIncrement;
+
+  /**
+    * Whether the clearDate iconbutton must be available when date is selected, default to false
+    */
+  showClearDate?: boolean;
+
+  /**
+   * Icon used for clearDate iconbutton. Defaults to RemoveEvent
+   */
+  showClearDateIcon?: string;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #1217

#### What's in this Pull Request?

Additional icon-button outside the datetime-picker which allows the user to clear the selected date by setting the day to null in state of datetimepicker.tsx . When no date is selected, the button is not visible. The used icon for the button is configurable, defaults to 'RemoveEvent'.

![image](https://user-images.githubusercontent.com/35333175/169546892-8fe57803-79bb-4933-beea-3a3a230a5892.png)


