### PR TITLE
PeoplePicker validation bugfix

### DIFF
--- a/src/controls/peoplepicker/IPeoplePicker.ts
+++ b/src/controls/peoplepicker/IPeoplePicker.ts
@@ -73,6 +73,10 @@ export interface IPeoplePickerProps {
    */
   onGetErrorMessage?: (items: IPersonaProps[]) => string | Promise<string>;
   /**
+   * Prop to validate contents on blur
+   */
+   validateOnFocusOut?: boolean;
+  /**
    * Method to check value of People Picker text
    */
   onChange?: (items: IPersonaProps[]) => void;

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -152,6 +152,15 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
     this.validate(items);
   }
 
+  /**
+   * On blur UI event
+   * @param ev 
+   */
+   private onBlur = (ev) => {
+    if (this.props.validateOnFocusOut)
+      this.validate(this.state.selectedPersons);
+  }
+
 
   /**
    * Returns the most recently used person
@@ -306,6 +315,7 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
           itemLimit={personSelectionLimit || 1}
           disabled={disabled || !!internalErrorMessage}
           onChange={this.onChange}
+          onBlur={this.onBlur}
           resolveDelay={resolveDelay} />
       </div>
     );

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -185,6 +185,10 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
 
     if (!result) {
       this.validated(items);
+
+      this.setState({
+        errorMessage: undefined
+      });
       return;
     }
 


### PR DESCRIPTION
Clear error message when onGetErrorMessage() returns empty string

| Q               | A
| --------------- | ---
| Bug fix?        | [X ]
| New feature?    | [X ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Update to the validate function to handle the props.onGetErrorMessage returning an empty string.  Addresses issue with people picker not clearing error message after passing validation after displaying an error message.

Update to add support for validateOnFocusOut


#### Guidance
- *You can delete this section when you are submitting the pull request.* 
- *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
- *Please target your PR to **dev** branch.*
