### PR TITLE
Fix missing pagecontext language

### DIFF
--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -424,10 +424,10 @@ export default class SPTermStorePickerService {
             resolve(null);
             return;
           }
-
+            
           let data = {
             start: searchText,
-            lcid: LocalesHelper.getLocaleId(this.context.pageContext.cultureInfo.currentUICultureName) ?? this.context.pageContext.web.language,
+            lcid: LocalesHelper.getLocaleId(this.context.pageContext.cultureInfo?.currentUICultureName) ?? this.context.pageContext.web.language,
 
             sspList: this.cleanGuid(termStore[0].Id),
             termSetList: TermSetId,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1226

#### What's in this Pull Request?

Added check if pageContext.cultureInfo exist before accessing pageContext.cultureInfo?.currentUICultureName
