### PR TITLE
Allow filters on a Toolbar to be controlled externally

### DIFF
--- a/docs/documentation/docs/controls/Toolbar.md
+++ b/docs/documentation/docs/controls/Toolbar.md
@@ -54,6 +54,13 @@ import { Toolbar } from '@pnp/spfx-controls-react/lib/Toolbar';
   find={true} />
 ```
 
+## Controlled or uncontrolled management of selected filters
+The Toolbar component can internally manage the set of selected filters (uncontrolled) or the set of selected filters can be defined using property, `selectedFilterIds `(controlled).
+
+If property `selectedFilterIds` is undefined then the set of selected filter IDs is uncontrolled and the Toolbar will initialise with an empty set of selected filters. As the user toggles the Toolbar's filters the function set on property, `onSelectedFiltersChange`, will be called with an array parameter of the currently selected filter IDs. The implementation of this function can return void or an array of filter IDs that the Toolbar should set. By returning an array of filter IDs the `onSelectedFiltersChange` implementation can alter the selected filters of an uncontrolled Toolbar in response to user attempts to set/clear filters.
+
+If the `selectedFilterIds` property is defined then the set of selected filter IDs is controlled and the Toolbar shall display selected filters according the contents of the array property. The `onSelectedFiltersChange` function will still be called, but the returned value will have no effect on the filters displayed as selected by the Toolbar.
+
 ## Implementation
 
 The Toolbar component can be configured with the following properties:
@@ -64,7 +71,8 @@ The Toolbar component can be configured with the following properties:
 | filters | TFilters | no | Toolbar filters. |
 | find | boolean | no | Specifies if searchbox should be displayed. |
 | filtersSingleSelect | boolean | no | Specifies if a user can select only one filter at a time. |
-| onSelectedFiltersChange | (selectedFilters: string[]) => string[] | no | Filter changed handler. |
+| onSelectedFiltersChange | (selectedFilters: string[]) => (string[] \| void) | no | Filter changed handler. Called when user toggles selection of a filter. |
+| selectedFilterIds | string[] | no | Specifies the IDs of the filters which should be displayed as selected by the Toolbar. |
 | onFindQueryChange | (findQuery: string) => string | no | Search query changed handler. |
 
 

--- a/src/controls/toolbar/Toolbar.tsx
+++ b/src/controls/toolbar/Toolbar.tsx
@@ -35,6 +35,11 @@ export interface IToolbarProps extends PropsOfElement<"div"> {
    */
   filters?: TFilters;
   /**
+   * When using the Toolbar as a controlled component, use this property to set the IDs of selected filters.
+   * Leave this property undefined to use the Toolbar as an uncontrolled component.
+   */
+  selectedFilterIds?: string[];
+  /**
    * Specifies if searchbox should be displayed
    */
   find?: boolean;
@@ -45,7 +50,7 @@ export interface IToolbarProps extends PropsOfElement<"div"> {
   /**
    * Filter changed handler
    */
-  onSelectedFiltersChange?: (selectedFilters: string[]) => string[];
+  onSelectedFiltersChange?: (selectedFilters: string[]) => (string[] | void);
   /**
    * Search query changed handler
    */
@@ -53,7 +58,7 @@ export interface IToolbarProps extends PropsOfElement<"div"> {
 }
 
 export const Toolbar = (props: IToolbarProps) => {
-  const { actionGroups, filters, filtersSingleSelect, find } = props;
+  const { actionGroups, filters, selectedFilterIds, filtersSingleSelect, find } = props;
 
   const allActions = flattenedActions(actionGroups);
 
@@ -169,6 +174,7 @@ export const Toolbar = (props: IToolbarProps) => {
                 <ToolbarFilter
                   layout={layout}
                   filters={filters}
+                  selectedFilterIds={selectedFilterIds}
                   singleSelect={!!filtersSingleSelect}
                   open={filtersOpen}
                   onOpenChange={(_e, changeProps) => {

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -262,6 +262,15 @@ const sampleItems = [
   }
 ];
 
+const toolbarFilters = [{
+  id: "filter1",
+  title: "filter1"
+},
+{
+  id: "filter2",
+  title: "filter2"
+}];
+
 /**
  * Component that can be used to test out the React controls from this project
  */
@@ -484,8 +493,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
       showErrorDialog: false,
       selectedTeam: [],
       selectedTeamChannels: [],
-      errorMessage: "This field is required"
-
+      errorMessage: "This field is required",
+      selectedFilters: ["filter1"]
     };
 
     this._onIconSizeChange = this._onIconSizeChange.bind(this);
@@ -700,6 +709,21 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
         console.log(fileResultContent);
       }
     }
+  }
+
+  private onToolbarSelectedFiltersChange = (filterIds: string[]) => {
+    this.setState({
+      selectedFilters: filterIds
+    });
+  }
+
+  private toggleToolbarFilter = (filterId: string) => {
+    this.setState(({selectedFilters}) => {
+    if (selectedFilters.includes(filterId)) {
+      return { selectedFilters: selectedFilters.filter(f => f !== filterId) };
+    } else {
+      return { selectedFilters: [...selectedFilters, filterId] };
+    }});
   }
 
   private rootFolder: IFolder = {
@@ -1885,6 +1909,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             size: WidgetSize.Single,
             link: linkExample,
           }]} />
+
+        <h3>Uncontrolled toolbar</h3>
         <Toolbar actionGroups={{
           'group1': {
             'action1': {
@@ -1898,7 +1924,33 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
               onClick: () => { console.log('New action click'); }
             }
           }
-        }} />
+        }}
+        filters={toolbarFilters}
+        onSelectedFiltersChange={this.onToolbarSelectedFiltersChange}
+        />
+
+        <div>
+        <h3>Controlled toolbar</h3>
+          <Toolbar actionGroups={{
+            'group1': {
+              'action1': {
+                title: 'Edit',
+                iconName: 'Edit',
+                onClick: () => { console.log('Edit action click'); }
+              },
+              'action2': {
+                title: 'New',
+                iconName: 'Add',
+                onClick: () => { console.log('New action click'); }
+              }
+            }}}
+            filters={toolbarFilters}
+            selectedFilterIds={this.state.selectedFilters}
+            onSelectedFiltersChange={this.onToolbarSelectedFiltersChange} />
+        </div>
+        <div>Selected filter IDs: {this.state.selectedFilters.join(", ")}</div>
+        <PrimaryButton text='Toggle filter1' onClick={() => this.toggleToolbarFilter("filter1")} />
+        <PrimaryButton text='Toggle filter2' onClick={() => this.toggleToolbarFilter("filter2")} />
 
         <div>
           <h3>Animated Dialogs</h3>

--- a/src/webparts/controlsTest/components/IControlsTestProps.ts
+++ b/src/webparts/controlsTest/components/IControlsTestProps.ts
@@ -49,4 +49,5 @@ export interface IControlsTestState {
   termPanelIsOpen?: boolean;
   actionTermId?: string;
   clickedActionTerm?: ITermInfo;
+  selectedFilters?: string[];
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #1222

#### What's in this Pull Request?

Additions to properties of Toolbar and Toolbar filter to permit external control of the selected filters displayed by the Toolbar.

Non-breaking signature change to Toolbar's onSelectedFiltersChange callback, allowing function implementations to return void rather than forcing implementations to return the set of selected filters that the Toolbar should display.

Highlight difference between controlled and uncontrolled Toolbars in the ControlsTest webpart. Users can operate buttons to toggle selected filters and observe that the Toolbar responds in a controlled manner.

Documentation changed to describe controlled vs uncontrolled use of the Toolbar.
