### PR TITLE
feat(PeoplePicker): add new `allowUnvalidated` option to allow adding non-tenant users

### DIFF
--- a/src/controls/peoplepicker/IPeoplePicker.ts
+++ b/src/controls/peoplepicker/IPeoplePicker.ts
@@ -114,6 +114,10 @@ export interface IPeoplePickerProps {
    */
   ensureUser?: boolean;
   /**
+   * When true, allow email addresses that have not been validated to be entered, effectively allowing any use
+   */
+  allowUnvalidated?: boolean;
+  /**
    * Placeholder to be displayed in an empty term picker
    */
   placeholder?: string;
@@ -149,4 +153,5 @@ export interface IPeoplePickerUserItem {
   secondaryText: string; // role
   tertiaryText: string; // status
   optionalText: string; // anything
+  userUnvalidated?: boolean;
 }

--- a/src/controls/peoplepicker/IPeoplePicker.ts
+++ b/src/controls/peoplepicker/IPeoplePicker.ts
@@ -114,7 +114,7 @@ export interface IPeoplePickerProps {
    */
   ensureUser?: boolean;
   /**
-   * When true, allow email addresses that have not been validated to be entered, effectively allowing any use
+   * When true, allow email addresses that have not been validated to be entered, effectively allowing any user
    */
   allowUnvalidated?: boolean;
   /**

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -75,7 +75,7 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
    * Get initial persons
    */
   private async getInitialPersons(props: IPeoplePickerProps) {
-    const { groupName, groupId, webAbsoluteUrl, defaultSelectedUsers, ensureUser, principalTypes } = props;
+    const { groupName, groupId, webAbsoluteUrl, defaultSelectedUsers, ensureUser, allowUnvalidated, principalTypes } = props;
     // Check if a group property was provided, and get the group ID
     if (groupName) {
       this.groupId = await this.peopleSearchService.getGroupId(groupName, webAbsoluteUrl);
@@ -101,7 +101,7 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
           valueAndTitle = userValue.split('/');
         }
 
-        const userResult = await this.peopleSearchService.searchPersonByEmailOrLogin(valueAndTitle[0], principalTypes, webAbsoluteUrl, this.groupId, ensureUser);
+        const userResult = await this.peopleSearchService.searchPersonByEmailOrLogin(valueAndTitle[0], principalTypes, webAbsoluteUrl, this.groupId, ensureUser, allowUnvalidated);
         if (userResult) {
           selectedPersons.push(userResult);
         }
@@ -124,7 +124,7 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
    */
   private onSearchFieldChanged = async (searchText: string, currentSelected: IPersonaProps[]): Promise<IPersonaProps[]> => {
     if (searchText.length > 2) {
-      const results = await this.peopleSearchService.searchPeople(searchText, this.suggestionsLimit, this.props.principalTypes, this.props.webAbsoluteUrl, this.groupId, this.props.ensureUser);
+      const results = await this.peopleSearchService.searchPeople(searchText, this.suggestionsLimit, this.props.principalTypes, this.props.webAbsoluteUrl, this.groupId, this.props.ensureUser, this.props.allowUnvalidated);
       // Remove duplicates
       const { selectedPersons, mostRecentlyUsedPersons } = this.state;
       const filteredPersons = this.removeDuplicates(results, selectedPersons);


### PR DESCRIPTION
Guest users can be identified by the `userUnvalidated` flag.

This is useful for then handling inviting users as guests.

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | 

#### What's in this Pull Request?

Adds new prop to the `PeoplePicker` component called `allowUnvalidated`. Setting this to true no longer filters out users which are "unvalidated", which in general means they do not exist in the tenant. This allows the picker to be used for example for an interface to invite guest users.

If a user is unvalidated, the `isUnvalidated` key will be true on the returned object.