### PR TITLE
Fixed LivePersona not showing card on hover

### DIFF
--- a/src/controls/LivePersona/LivePersona.tsx
+++ b/src/controls/LivePersona/LivePersona.tsx
@@ -37,7 +37,8 @@ if (isComponentLoaded) {
         hostAppPersonaInfo: {
             PersonaType: 'User'
         },
-        upn:  upn,
+        upn: upn,
+        legacyUpn: upn,
         serviceScope: serviceScope,
     }, createElement("div",{},template));
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  |  https://github.com/pnp/sp-dev-fx-controls-react/issues/1241

#### What's in this Pull Request?

`LivePersona` component stopped working. Microsoft changed `LivePersonaCard` component's property `upn` to `legacyUpn`.

Fixed `LivePersona` component by adding `legacyUpn` property. 
Decided to keep `upn` property in case this is still used on Standard Release tenants.
