### PR TITLE
Added the possibility to override field rendering for individual field

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -68,11 +68,18 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
       fieldCollection,
       isSaving
     } = this.state;
+    
+    const fieldOverrides = this.props.fieldOverrides;
+    
     return (
       <div>
         {fieldCollection.length === 0 ? <div><ProgressIndicator label={strings.DynamicFormLoading} description={strings.DynamicFormPleaseWait} /></div> :
           <div>
             {fieldCollection.map((v, i) => {
+              if(fieldOverrides?.hasOwnProperty(v.columnInternalName)) {
+                v.disabled = v.disabled || isSaving;
+                return fieldOverrides[v.columnInternalName](v);
+              }
               return <DynamicField {...v} disabled={v.disabled || isSaving} />;
             })}
             {

--- a/src/controls/dynamicForm/IDynamicFormProps.ts
+++ b/src/controls/dynamicForm/IDynamicFormProps.ts
@@ -1,5 +1,7 @@
 import { BaseComponentContext } from '@microsoft/sp-component-base';
 import { IItem } from '@pnp/sp/items';
+import React from 'react';
+import { IDynamicFieldProps } from './dynamicField';
 
 export interface IDynamicFormProps {
   /**
@@ -40,6 +42,10 @@ export interface IDynamicFormProps {
    */
   contentTypeId?: string;
 
+  /**
+   * Key value pair for fields you want to override.  Key is the internal field name, value is the function to be called for the custom element to render
+   */
+  fieldOverrides?: {[columnInternalName: string] : {(fieldProperties: IDynamicFieldProps): React.ReactElement<IDynamicFieldProps>}};
   /**
    * Specifies if onSubmitted event should pass PnPJS list item (IItem) as a second parameter. Default - true
    */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | fixes #1257 

#### What's in this Pull Request?
Added the possibility to configure that some of the form's fields have a custom renderer. While I initially intended to do this via the children,  I came to the conclusion this was not a very good solution, so I implemented it through the DynamicForm's properties. I introduced the optional fieldOverrides property that can be set as follows:

```typescript
<DynamicForm context={this.props.context} listId={"1d503fec-3680-40f4-9d92-e175cbc0d33c"} onCancelled={() => { console.log('Cancelled'); }} onSubmitted={async (listItem) => { let itemdata = await listItem.get(); console.log(itemdata["ID"]); }}
  fieldOverrides={{"TestField1": (fieldProperties: IDynamicFieldProps) => <DropdownForTextField {...fieldProperties}/> }}
/>
```

This configures that TestField1 should be rendered using the custom DropdownForTextField component, which is a simple implementation of a dropdownfield, that will set the selectedtext as the new value for the field. All other logic (saving etc.) is used from the DynamicForm

```typescript
import { Dropdown, IDropdownOption } from 'office-ui-fabric-react';
import * as React from 'react';
import { IDynamicFieldProps } from '../../../controls/dynamicForm/dynamicField';
export class DropdownForTextField extends React.Component<IDynamicFieldProps, {}> {

    constructor(props: any) {
        super(props);
    }

    public componentDidUpdate() {
    }
    private _onChange = (event: React.FormEvent, option: IDropdownOption, index: number)=> {
        this.props.onChanged(this.props.columnInternalName, option.text);
    }

    public render(): JSX.Element {
        try {
            return (
                <div>
                    The field {this.props.columnInternalName} has a custom renderer <br />
                    <Dropdown onChange={this._onChange}
                        options={[
                            { key: 'A', text: 'Option a' },
                            { key: 'B', text: 'Option b' },
                            { key: 'C', text: 'Option c' },
                            { key: 'D', text: 'Option d' },
                            { key: 'E', text: 'Option e' },
                        ]}/>
                </div>
            );
        } catch (error) {
            console.log(`Error in DynamicField render`, error);
            return null;
        }
    }
}
```

Without the custom renderer specified, everything is rendered according to the default specification (as a TextField in this example  
![image](https://user-images.githubusercontent.com/12426259/178147999-1b043af1-2075-49cc-b8a8-2437054fdc5b.png)


But with this custom renderer, this field is rendered as a dropdown:  
![image](https://user-images.githubusercontent.com/12426259/178147863-d89ee2e9-0afa-4b33-b9d5-54bbc3a46c92.png)

![image](https://user-images.githubusercontent.com/12426259/178147927-ea4db871-4e94-487a-be8b-ba474845dfe0.png)

This will need to be documented in more detail in the documentation, but let's first agree if this is the best way to implement this