### PR TITLE
fix(people picker): fixes #1292 where people picker returns no results.

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,6 +1,20 @@
 {
   "versions": [
     {
+      "version": "3.11.0",
+      "changes": {
+        "new": [],
+        "enhancements": [
+          "`DynamicForm`: Add taxonomy tree to test harness [#1269](https://github.com/pnp/sp-dev-fx-controls-react/pull/1269)"
+        ],
+        "fixes": [
+        ]
+      },
+      "contributions": [
+        "[Hilton Giesenow](https://github.com/HiltonGiesenow)"
+      ]
+    },
+    {
       "version": "3.10.0",
       "changes": {
         "new": [],

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -5,7 +5,8 @@
       "changes": {
         "new": [],
         "enhancements": [
-          "`DynamicForm`: Add taxonomy tree to test harness [#1269](https://github.com/pnp/sp-dev-fx-controls-react/pull/1269)"
+          "`DynamicForm`: Add taxonomy tree to test harness [#1269](https://github.com/pnp/sp-dev-fx-controls-react/pull/1269)",
+          "`ModernTaxonomyPicker`: ability to disallow selecting children [#1279](https://github.com/pnp/sp-dev-fx-controls-react/pull/1279)"
         ],
         "fixes": [
           "`FilePicker`: Tile view fix [#1272](https://github.com/pnp/sp-dev-fx-controls-react/issues/1272)"
@@ -13,6 +14,7 @@
       },
       "contributions": [
         "[Hilton Giesenow](https://github.com/HiltonGiesenow)",
+        "[Jake Stanger](https://github.com/JakeStanger)",
         "[Victor Romanov](https://github.com/VRomanovTau)"
       ]
     },

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -8,10 +8,12 @@
           "`DynamicForm`: Add taxonomy tree to test harness [#1269](https://github.com/pnp/sp-dev-fx-controls-react/pull/1269)"
         ],
         "fixes": [
+          "`FilePicker`: Tile view fix [#1272](https://github.com/pnp/sp-dev-fx-controls-react/issues/1272)"
         ]
       },
       "contributions": [
-        "[Hilton Giesenow](https://github.com/HiltonGiesenow)"
+        "[Hilton Giesenow](https://github.com/HiltonGiesenow)",
+        "[Victor Romanov](https://github.com/VRomanovTau)"
       ]
     },
     {

--- a/docs/documentation/docs/controls/ModernTaxonomyPicker.md
+++ b/docs/documentation/docs/controls/ModernTaxonomyPicker.md
@@ -177,6 +177,7 @@ The ModernTaxonomyPicker control can be configured with the following properties
 | isBlocking | boolean | no | Whether the panel uses a modal overlay or not. |
 | onRenderActionButton | function | no | Optional custom renderer for adding e.g. a button with additional actions to the terms in the tree view. |
 | isPathRendered | boolean | no | Whether the terms will be rendered with the term label or the full path up to the root. |
+| allowSelectingChildren | boolean | no | Whether child terms can be selected. Default value is true. |
 
 ## Standalone TaxonomyTree control
 

--- a/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
+++ b/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx
@@ -196,7 +196,7 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
                       />) :
                     (<TilesList
                       fileBrowserService={this.props.fileBrowserService}
-                      filePickerResult={this.state.filePickerResults ? this.state.filePickerResults[0] : null}
+                      filePickerResults={this.state.filePickerResults ? this.state.filePickerResults : null}
                       selection={this._selection}
                       items={this.state.items}
                       onFolderOpen={this._handleOpenFolder}
@@ -518,6 +518,8 @@ export class FileBrowser extends React.Component<IFileBrowserProps, IFileBrowser
       if (filesQueryResult.nextHref !== null) {
         newItems.push(null);
       }
+
+      this._selection.setItems(newItems);
 
       if (!concatenateResults) {
         // de-select anything that was previously selected

--- a/src/controls/filePicker/controls/TilesList/ITilesListProps.ts
+++ b/src/controls/filePicker/controls/TilesList/ITilesListProps.ts
@@ -5,7 +5,7 @@ import { IFilePickerResult } from "../../FilePicker.types";
 
 export interface ITilesListProps {
   fileBrowserService: FileBrowserService;
-  filePickerResult: IFilePickerResult;
+  filePickerResults: IFilePickerResult[];
   selection: Selection;
   items: IFile[];
 

--- a/src/controls/filePicker/controls/TilesList/TilesList.tsx
+++ b/src/controls/filePicker/controls/TilesList/TilesList.tsx
@@ -52,7 +52,7 @@ export class TilesList extends React.Component<ITilesListProps> {
   }
 
   public componentDidUpdate(prevProps: ITilesListProps): void {
-    if (this.props.filePickerResult !== prevProps.filePickerResult) {
+    if (this.props.filePickerResults !== prevProps.filePickerResults) {
       this._listElem.forceUpdate();
     }
   }
@@ -163,7 +163,7 @@ export class TilesList extends React.Component<ITilesListProps> {
       this.props.onNextPageDataRequest();
       return null;
     }
-    const isSelected: boolean = this.props.filePickerResult && item.absoluteUrl === this.props.filePickerResult.fileAbsoluteUrl;
+    const isSelected: boolean = this.props.filePickerResults.filter(x => x.fileAbsoluteUrl === item.absoluteUrl).length > 0;
 
     // I know this is a lot of divs and spans inside of each other, but my
     // goal was to mimic the HTML and style of the out-of-the-box file picker

--- a/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
+++ b/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
@@ -61,6 +61,7 @@ export interface IModernTaxonomyPickerProps {
   isLightDismiss?: boolean;
   isBlocking?: boolean;
   onRenderActionButton?: (termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo?: ITermInfo) => JSX.Element;
+  allowSelectingChildren?: boolean;
 }
 
 export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps): JSX.Element {
@@ -160,7 +161,8 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps): JSX.Ele
     if (filter === '') {
       return [];
     }
-    const filteredTerms = await taxonomyService.searchTerm(Guid.parse(props.termSetId), filter, currentLanguageTag, props.anchorTermId ? Guid.parse(props.anchorTermId) : Guid.empty);
+    const filteredTerms = await taxonomyService.searchTerm(Guid.parse(props.termSetId), filter, currentLanguageTag, props.anchorTermId ? Guid.parse(props.anchorTermId) : Guid.empty, props.allowSelectingChildren);
+
     const filteredTermsWithParentInformation = props.isPathRendered ? await addParentInformationToTerms(filteredTerms) : filteredTerms;
     const filteredTermsWithoutSelectedItems = filteredTermsWithParentInformation.filter((term) => {
       if (!selectedItems || selectedItems.length === 0) {
@@ -168,7 +170,11 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps): JSX.Ele
       }
       return selectedItems.every((item) => item.id !== term.id);
     });
-    const filteredTermsAndAvailable = filteredTermsWithoutSelectedItems.filter((term) => term.isAvailableForTagging.filter((t) => t.setId === props.termSetId)[0].isAvailable);
+
+    const filteredTermsAndAvailable = filteredTermsWithoutSelectedItems
+      .filter((term) =>
+        term.isAvailableForTagging
+          .filter((t) => t.setId === props.termSetId)[0].isAvailable);
     return filteredTermsAndAvailable;
   }
 
@@ -329,6 +335,7 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps): JSX.Ele
                 themeVariant={props.themeVariant}
                 termPickerProps={props.termPickerProps}
                 onRenderActionButton={props.onRenderActionButton}
+                allowSelectingChildren={props.allowSelectingChildren}
               />
             </div>
           )

--- a/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyPanelContents/TaxonomyPanelContents.tsx
@@ -39,6 +39,7 @@ export interface ITaxonomyPanelContentsProps {
   themeVariant?: IReadonlyTheme;
   termPickerProps?: Optional<IModernTermPickerProps, 'onResolveSuggestions'>;
   onRenderActionButton?: (termStoreInfo: ITermStoreInfo, termSetInfo: ITermSetInfo, termInfo: ITermInfo, updateTaxonomyTreeViewCallback?: (newTermItems?: ITermInfo[], updatedTermItems?: ITermInfo[], deletedTermItems?: ITermInfo[]) => void) => JSX.Element;
+  allowSelectingChildren?: boolean;
 }
 
 export function TaxonomyPanelContents(props: ITaxonomyPanelContentsProps): React.ReactElement<ITaxonomyPanelContentsProps> {
@@ -114,6 +115,7 @@ export function TaxonomyPanelContents(props: ITaxonomyPanelContentsProps): React
         onRenderActionButton={props.onRenderActionButton}
         hideDeprecatedTerms={true}
         showIcons={false}
+        allowSelectingChildren={props.allowSelectingChildren}
       />
     </div>
   );

--- a/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
+++ b/src/controls/modernTaxonomyPicker/taxonomyTree/TaxonomyTree.tsx
@@ -58,6 +58,7 @@ export interface ITaxonomyTreeProps {
   selection?: Selection<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   hideDeprecatedTerms?: boolean;
   showIcons?: boolean;
+  allowSelectingChildren?: boolean;
 }
 
 export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITaxonomyTreeProps> {
@@ -228,7 +229,7 @@ export function TaxonomyTree(props: ITaxonomyTreeProps): React.ReactElement<ITax
               level: 1,
               isCollapsed: true,
               data: { skiptoken: '', term: term },
-              hasMoreData: term.childrenCount > 0,
+              hasMoreData: props.allowSelectingChildren !== false && term.childrenCount > 0,
             };
             if (g.hasMoreData) {
               g.children = [];

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -110,7 +110,7 @@ export default class SPPeopleSearchService {
     try {
       // If the running env is SharePoint, loads from the peoplepicker web service
       const userRequestUrl: string = `${siteUrl || this.context.pageContext.web.absoluteUrl}/_api/SP.UI.ApplicationPages.ClientPeoplePickerWebServiceInterface.clientPeoplePickerSearchUser`;
-      const searchBody = {
+      const searchBody: any = {
         queryParams: {
           AllowEmailAddresses: true,
           AllowMultipleEntities: false,
@@ -124,12 +124,12 @@ export default class SPPeopleSearchService {
 
       // Search on the local site when "0"
       if (siteUrl) {
-        searchBody.queryParams["SharePointGroupID"] = 0;
+        searchBody.queryParams.SharePointGroupID = 0;
       }
 
       // Check if users need to be searched in a specific SharePoint Group
       if (groupId && typeof (groupId) === 'number') {
-        searchBody.queryParams["SharePointGroupID"] = groupId;
+        searchBody.queryParams.SharePointGroupID = groupId;
       }
 
       // Check if users need to be searched in a specific Microsoft 365 Group, Security Group (incl. nested groups) or Distribution List

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -119,18 +119,17 @@ export default class SPPeopleSearchService {
           PrincipalSource: 15,
           PrincipalType: this.getSumOfPrincipalTypes(principalTypes),
           QueryString: query,
-          SharePointGroupID: null
         }
       };
 
       // Search on the local site when "0"
       if (siteUrl) {
-        searchBody.queryParams.SharePointGroupID = 0;
+        searchBody.queryParams["SharePointGroupID"] = 0;
       }
 
       // Check if users need to be searched in a specific SharePoint Group
       if (groupId && typeof (groupId) === 'number') {
-        searchBody.queryParams.SharePointGroupID = groupId;
+        searchBody.queryParams["SharePointGroupID"] = groupId;
       }
 
       // Check if users need to be searched in a specific Microsoft 365 Group, Security Group (incl. nested groups) or Distribution List

--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -203,7 +203,7 @@ export default class SPPeopleSearchService {
             for (const value of values) {
               // Only ensure the user if it is not a SharePoint group
               if (!value.EntityData || (value.EntityData && typeof value.EntityData.SPGroupID === "undefined" && value.EntityData.PrincipalType !== "UNVALIDATED_EMAIL_ADDRESS")) {
-                const id = await this.ensureUser(value.Key);
+                const id = await this.ensureUser(value.Key, siteUrl || this.context.pageContext.web.absoluteUrl);
                 value.LoginName = value.Key;
                 value.Key = id;
               }
@@ -272,9 +272,10 @@ export default class SPPeopleSearchService {
    * Retrieves the local user ID
    *
    * @param userId
+   * @param siteUrl
    */
-  private async ensureUser(userId: string): Promise<number> {
-    const siteUrl = this.context.pageContext.web.absoluteUrl;
+  private async ensureUser(userId: string, siteUrl: string): Promise<number> {
+    // const siteUrl = this.context.pageContext.web.absoluteUrl;
     if (this.cachedLocalUsers && this.cachedLocalUsers[siteUrl]) {
       const users = this.cachedLocalUsers[siteUrl];
       const userIdx = findIndex(users, u => u.LoginName === userId);

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -501,9 +501,9 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
       selectedTeamChannels: [],
       errorMessage: "This field is required",
       selectedFilters: ["filter1"],
-	  termStoreInfo: null,
-	  termSetInfo: null,
-	  testTerms: [],
+      termStoreInfo: null,
+      termSetInfo: null,
+      testTerms: [],
     };
 
     this._onIconSizeChange = this._onIconSizeChange.bind(this);
@@ -518,13 +518,13 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
   public async componentDidMount() {
     const restApi = `${this.props.context.pageContext.web.absoluteUrl}/_api/web/GetFolderByServerRelativeUrl('Shared%20Documents')/files?$expand=ListItemAllFields`;
     const response = await this.props.context.spHttpClient.get(restApi, SPHttpClient.configurations.v1);
-	const items = await response.json();
+    const items = await response.json();
 
-	this.setState({
-		items: items.value ? items.value : [],
-		termStoreInfo: await this.spTaxonomyService.getTermStoreInfo(),
-		termSetInfo: await this.spTaxonomyService.getTermSetInfo(Guid.parse("4bc86596-7caf-4e70-80c9-d9769e448988")),  
-	});
+    this.setState({
+      items: items.value ? items.value : [],
+      termStoreInfo: await this.spTaxonomyService.getTermStoreInfo(),
+      termSetInfo: await this.spTaxonomyService.getTermSetInfo(Guid.parse("4bc86596-7caf-4e70-80c9-d9769e448988")),
+    });
 
     // // Get Authors in the SharePoint Document library -- For People Picker Testing
     // const restAuthorApi = `${this.props.context.pageContext.web.absoluteUrl}/_api/web/lists/GetByTitle('Documents')/Items?$select=Id, Author/EMail&$expand=Author/EMail`;
@@ -728,12 +728,13 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
   }
 
   private toggleToolbarFilter = (filterId: string) => {
-    this.setState(({selectedFilters}) => {
-    if (selectedFilters.includes(filterId)) {
-      return { selectedFilters: selectedFilters.filter(f => f !== filterId) };
-    } else {
-      return { selectedFilters: [...selectedFilters, filterId] };
-    }});
+    this.setState(({ selectedFilters }) => {
+      if (selectedFilters.includes(filterId)) {
+        return { selectedFilters: selectedFilters.filter(f => f !== filterId) };
+      } else {
+        return { selectedFilters: [...selectedFilters, filterId] };
+      }
+    });
   }
 
   private rootFolder: IFolder = {
@@ -1937,12 +1938,12 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             }
           }
         }}
-        filters={toolbarFilters}
-        onSelectedFiltersChange={this.onToolbarSelectedFiltersChange}
+          filters={toolbarFilters}
+          onSelectedFiltersChange={this.onToolbarSelectedFiltersChange}
         />
 
         <div>
-        <h3>Controlled toolbar</h3>
+          <h3>Controlled toolbar</h3>
           <Toolbar actionGroups={{
             'group1': {
               'action1': {
@@ -1955,7 +1956,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
                 iconName: 'Add',
                 onClick: () => { console.log('New action click'); }
               }
-            }}}
+            }
+          }}
             filters={toolbarFilters}
             selectedFilterIds={this.state.selectedFilters}
             onSelectedFiltersChange={this.onToolbarSelectedFiltersChange} />
@@ -2345,7 +2347,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           <AdaptiveCardDesignerHost
             headerText={`Adaptive Card Designer`}
             buttonText="Open Designer"
-            card={{"$schema":"http://adaptivecards.io/schemas/adaptive-card.json","type":"AdaptiveCard","version":"1.5","body":[{"type":"ColumnSet","columns":[{"width":"auto","items":[{"type":"Image","size":"Small","style":"Person","url":"/_layouts/15/userphoto.aspx?size=M&username=${$root['@context']['userInfo']['email']}"}],"type":"Column"},{"width":"stretch","items":[{"type":"TextBlock","text":"${$root['@context']['userInfo']['displayName']}","weight":"Bolder"},{"type":"TextBlock","spacing":"None","text":"${$root['@context']['userInfo']['email']}"}],"type":"Column"}]}]}}
+            card={{ "$schema": "http://adaptivecards.io/schemas/adaptive-card.json", "type": "AdaptiveCard", "version": "1.5", "body": [{ "type": "ColumnSet", "columns": [{ "width": "auto", "items": [{ "type": "Image", "size": "Small", "style": "Person", "url": "/_layouts/15/userphoto.aspx?size=M&username=${$root['@context']['userInfo']['email']}" }], "type": "Column" }, { "width": "stretch", "items": [{ "type": "TextBlock", "text": "${$root['@context']['userInfo']['displayName']}", "weight": "Bolder" }, { "type": "TextBlock", "spacing": "None", "text": "${$root['@context']['userInfo']['email']}" }], "type": "Column" }] }] }}
             data={undefined}
             context={this.props.context}
             theme={this.props.themeVariant}
@@ -2388,22 +2390,22 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           />
         </div>
 
-		<div>
+        <div>
           <h3>Modern Taxonomy Tree</h3>
-		  {this.state.termStoreInfo && (
-          <TaxonomyTree
-			languageTag={this.state.termStoreInfo.defaultLanguageTag}
-			onLoadMoreData={this.spTaxonomyService.getTerms}
-			pageSize={50}
-			setTerms={(value) => this.setState({testTerms: value as any})}
-			termStoreInfo={this.state.termStoreInfo}
-			termSetInfo={this.state.termSetInfo}
-			terms={this.state.testTerms as any[]}
-			onRenderActionButton={() => <button>test button</button>}
-			hideDeprecatedTerms={false}
-			showIcons={true}
-			/>
-		  )}
+          {this.state.termStoreInfo && (
+            <TaxonomyTree
+              languageTag={this.state.termStoreInfo.defaultLanguageTag}
+              onLoadMoreData={this.spTaxonomyService.getTerms}
+              pageSize={50}
+              setTerms={(value) => this.setState({ testTerms: value as any })}
+              termStoreInfo={this.state.termStoreInfo}
+              termSetInfo={this.state.termSetInfo}
+              terms={this.state.testTerms as any[]}
+              onRenderActionButton={() => <button>test button</button>}
+              hideDeprecatedTerms={false}
+              showIcons={true}
+            />
+          )}
         </div>
 
       </div>

--- a/src/webparts/controlsTest/components/ControlsTest_SingleComponent.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest_SingleComponent.tsx
@@ -143,6 +143,9 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
       termPanelIsOpen: false,
       actionTermId: null,
       clickedActionTerm: null,
+	  termStoreInfo: null,
+	  termSetInfo: null,
+	  testTerms: [],
     };
 
     this._onIconSizeChange = this._onIconSizeChange.bind(this);

--- a/src/webparts/controlsTest/components/IControlsTestProps.ts
+++ b/src/webparts/controlsTest/components/IControlsTestProps.ts
@@ -8,7 +8,8 @@ import {
   IReadonlyTheme,
 
 } from "@microsoft/sp-component-base";
-import { ITermInfo } from '@pnp/sp/taxonomy';
+import { ITermInfo, ITermSetInfo, ITermStoreInfo } from '@pnp/sp/taxonomy';
+
 export interface IControlsTestProps {
   context: WebPartContext;
   description: string;
@@ -53,4 +54,7 @@ export interface IControlsTestState {
   actionTermId?: string;
   clickedActionTerm?: ITermInfo;
   selectedFilters?: string[];
+  termStoreInfo: ITermStoreInfo;
+  termSetInfo: ITermSetInfo;
+  testTerms: ITermInfo[];
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?
Reverted changes previously made for 1.15 support that cause the people picker to return 0 results.

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.

People picker queryParams was including a SharePointGroupID param with null value by default and the API does not allow null values for this param.

