### PR TITLE
Placeholder example to only display in edit mode. Closes #1280 

### DIFF
--- a/docs/documentation/docs/controls/Placeholder.md
+++ b/docs/documentation/docs/controls/Placeholder.md
@@ -56,6 +56,21 @@ Sample of using the `hideButton` functionality for hiding the button when page i
              theme={this.props.themeVariant} />
 ```
 
+Sample to only display `Placeholder` when the web part is in edit mode:
+
+```TypeScript
+{
+  this.displayMode === DisplayMode.Edit ?
+  <Placeholder iconName='Edit'
+               iconText='Configure your web part'
+               description='Please configure the web part.'
+               buttonLabel='Configure'
+               onConfigure={this._onConfigure}
+               theme={this.props.themeVariant} /> :
+  <div />
+}
+```
+
 ## Implementation
 
 The placeholder control can be configured with the following properties:


### PR DESCRIPTION
| Q               | A
| --------------- | :---:
| Bug fix?        | 
| New feature?    | ✔️
| New sample?      | 
| Related issues?  | fixes #1280 

#### What's in this Pull Request?

Extending the control Placeholder with an extra option `hideInReadMode` that would hide the control when the display mode of the page is in `read`. 