### PR TITLE
Fix broken arrow icons on RichText component

### DIFF
--- a/src/controls/richText/RichText.module.scss
+++ b/src/controls/richText/RichText.module.scss
@@ -93,7 +93,6 @@
   font-weight: normal;
   font-size: 8px;
   speak: none;
-  font-family: "FabricMDL2Icons-6";
   top: 50%;
   color: $ms-color-neutralLighterAlt;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Fixes the broken down arrow in the RichText component's toolbar. Seems there was still an explicit icon font family reference that no longer exists after recent Fluent icon updates in SharePoint Online. e.g.

Before fix:

![image](https://user-images.githubusercontent.com/985283/188240139-4cae42d4-d4ac-4bfc-95d2-d3aba0397073.png)

After fix:

![image](https://user-images.githubusercontent.com/985283/188240170-7b523bd8-c718-4423-9a0a-eeda0ed52979.png)

Thanks!