### PR TITLE
Bugfix/#1306 fix initial term resolution looping

### DIFF
--- a/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
+++ b/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
@@ -108,7 +108,9 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps): JSX.Ele
           // no-op;
         });
     }
-  }, [currentTermStoreInfo?.defaultLanguageTag, props.anchorTermId, props.context.pageContext, props.initialValues, props.termSetId, taxonomyService]);
+  },
+    // Do NOT add initial values as dependencies because it should trigger term resolution when the component rerender (https://github.com/pnp/sp-dev-fx-controls-react/issues/1306)
+    [currentTermStoreInfo?.defaultLanguageTag, props.anchorTermId, props.context.pageContext, props.termSetId, taxonomyService]);
 
   React.useEffect(() => {
     if (props.onChange && initialLoadComplete.current) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1306

#### What's in this Pull Request?

`initialValues` property was part of the dependency of the react effect that resolve the terms. This resolution trigger the onchange event, which results in updating the state in a controlled use of the control. This rerender will set again initial values, and the infinite loop occurs.

Removing this initialValues solve this loop
