### PR TITLE
Fixed initialization of SPTermStorePickerService.ts

### DIFF
--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -28,6 +28,8 @@ export default class SPTermStorePickerService {
    * Service constructor
    */
   constructor(private props: ITaxonomyPickerProps, private context: BaseComponentContext) {
+    this.clientServiceUrl = this.context.pageContext.web.absoluteUrl + '/_vti_bin/client.svc/ProcessQuery';
+    this.suggestionServiceUrl = this.context.pageContext.web.absoluteUrl + "/_vti_bin/TaxonomyInternalService.json/GetSuggestions";
   }
 
   public async getTermLabels(termId: string): Promise<string[]> {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1299 #1303 

#### What's in this Pull Request?

In Version 3.10 there were changes to the SPTermStorePickerService, which broke it. I reverted to the old initialization, without the check if its a local version, as the use of the mock service got removed completely!

If I should change something in the initialization, please let me know!

Cheers!
