### PR TITLE
Fix - Wrong preselected user in dynamic form

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -443,7 +443,7 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
           else if (fieldType === "User") {
             if (item !== null) {
               const userEmails: string[] = [];
-              userEmails.push(await this._spService.getUsersUPNFromFieldValue(listId, listItemId, field.InternalName, this.webURL) + '');
+              userEmails.push(await this._spService.getUserUPNFromFieldValue(listId, listItemId, field.InternalName, this.webURL) + '');
               defaultValue = userEmails;
             }
             else {

--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -443,7 +443,7 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
           else if (fieldType === "User") {
             if (item !== null) {
               const userEmails: string[] = [];
-              userEmails.push(await this._spService.getUserUPNById(parseInt(item[field.InternalName + "Id"])) + '');
+              userEmails.push(await this._spService.getUsersUPNFromFieldValue(listId, listItemId, field.InternalName, this.webURL) + '');
               defaultValue = userEmails;
             }
             else {

--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -281,28 +281,16 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
       field.newValue = [];
       for (let index = 0; index < newValue.length; index++) {
         const element = newValue[index];
-        let retrivedItem = false;
-        if (field.fieldDefaultValue !== null) {
-          if (field.fieldDefaultValue.join(',').indexOf(element.text) !== -1)
-            field.fieldDefaultValue.forEach(item => {
-              if (item.split('/')[1] === element.text) {
-                retrivedItem = true;
-                field.newValue.push(item.split('/')[0]);
-              }
-            });
+        if (element.id === undefined || parseInt(element.id, 10).toString() === "NaN") {
+          let user: string = element.secondaryText;
+          if (user.indexOf('@') === -1) {
+            user = element.loginName;
+          }
+          const result = await sp.web.ensureUser(user);
+          field.newValue.push(result.data.Id);
         }
-        if (!retrivedItem) {
-          if (element.id === undefined || parseInt(element.id, 10).toString() === "NaN") {
-            let user: string = element.secondaryText;
-            if (user.indexOf('@') === -1) {
-              user = element.loginName;
-            }
-            const result = await sp.web.ensureUser(user);
-            field.newValue.push(result.data.Id);
-          }
-          else {
-            field.newValue.push(element.id);
-          }
+        else {
+          field.newValue.push(element.id);
         }
       }
     }

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -575,7 +575,7 @@ export default class SPService implements ISPService {
   public async getUsersUPNFromFieldValue(listId: string, listItemId: number, fieldName: string, webUrl?: string): Promise<any[]> { // eslint-disable-line @typescript-eslint/no-explicit-any
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemId})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/Title,${fieldName}/Id&$expand=${fieldName}`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemId})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/Title,${fieldName}/Id,${fieldName}/Name&$expand=${fieldName}`;
 
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {
@@ -583,7 +583,8 @@ export default class SPService implements ISPService {
         if (result && result[fieldName]) {
           const emails = [];
           result[fieldName].forEach(element => {
-            emails.push(element.Id + "/" + element.Title);
+            const loginNameWithoutClaimsToken = element.Name.split("|").pop();
+            emails.push(loginNameWithoutClaimsToken + "/" + element.Title);
           });
           return emails;
         }
@@ -605,7 +606,7 @@ export default class SPService implements ISPService {
       if (data.ok) {
         const results = await data.json();
         if (results) {
-          return userId + "/" + results.Title;
+          return results.UserPrincipalName + "/" + results.Title;
         }
       }
 

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -597,16 +597,18 @@ export default class SPService implements ISPService {
     }
   }
 
-  public async getUserUPNById(userId: number, webUrl?: string): Promise<string> {
+  public async getUserUPNFromFieldValue(listId: string, listItemId: number, fieldName: string, webUrl?: string): Promise<any> {
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/getuserbyid(${userId})?$select=UserPrincipalName,Title`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemId})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/Title,${fieldName}/Id,${fieldName}/Name&$expand=${fieldName}`;
 
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {
-        const results = await data.json();
-        if (results) {
-          return results.UserPrincipalName + "/" + results.Title;
+        const result = await data.json();
+        if (result && result[fieldName]) {
+          const element = result[fieldName]
+            const loginNameWithoutClaimsToken = element.Name.split("|").pop();
+            return loginNameWithoutClaimsToken + "/" + element.Title;
         }
       }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1315 

#### What's in this Pull Request?
I changed the way the DynamicForm component fetches the initial data from user fields. I changed it to use the UPN instead of the ID, because as described in issue #1315, this leads to problems when "People and Groups" are enabled in the SharePoint field.

I had to also remove the parsing of the user IDs from the defaultValues, because there are no longer the IDs there.

