### PR TITLE
Fix the problem of import the monacoEditor control

### DIFF
--- a/src/MonacoEditor.ts
+++ b/src/MonacoEditor.ts
@@ -1,0 +1,1 @@
+export * from './controls/monacoEditor';

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,3 +42,4 @@ export * from './Carousel';
 export * from './ModernTaxonomyPicker';
 export * from './LivePersona';
 export * from './ModernAudio';
+export * from './MonacoEditor';

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -190,6 +190,7 @@ import { ControlsTestEnhancedThemeProvider, ControlsTestEnhancedThemeProviderFun
 import { AdaptiveCardDesignerHost } from "../../../AdaptiveCardDesignerHost";
 import { ModernAudio, ModernAudioLabelPosition } from "../../../ModernAudio";
 import { SPTaxonomyService, TaxonomyTree } from "../../../ModernTaxonomyPicker";
+import { TestControl } from "./TestControl";
 
 
 // Used to render document card
@@ -2406,6 +2407,11 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
               showIcons={true}
             />
           )}
+        </div>
+
+        <div>
+          <h3>Monaco Editor</h3>
+          <TestControl context={this.props.context} />
         </div>
 
       </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1323 

#### What's in this Pull Request?
I fixed the problem described into the issue #1323 
Now it's possible to import using the standard import 
`import { MonacoEditor } from "@pnp/spfx-controls-react/lib/MonacoEditor";`
