### PR TITLE
Fixes#1337 the problem of importing the control

### DIFF
--- a/src/controls/contentTypePicker/ContentTypePicker.tsx
+++ b/src/controls/contentTypePicker/ContentTypePicker.tsx
@@ -1,5 +1,5 @@
 import * as telemetry from '../../common/telemetry';
-import React from 'react';
+import * as React from 'react';
 import { IContentTypePickerProps, IContentTypePickerState } from './IContentTypePicker';
 import { ISPService } from '../../services/ISPService';
 import { SPServiceFactory } from '../../services/SPServiceFactory';


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | Can't use the ContentTypePicker control #1337 

#### What's in this Pull Request?

The control "ContentTypePicker" can't be used with the preview configuration, it returns an error 

`(alias) class ContentTypePicker
import ContentTypePicker
JSX element class does not support attributes because it does not have a 'props' property.ts(2607)`

`'ContentTypePicker' cannot be used as a JSX component.
  Its instance type 'ContentTypePicker' is not a valid JSX element.
    Type 'ContentTypePicker' is missing the following properties from type 'ElementClass': context, setState, forceUpdate, props, and 2 more.ts(2786)`


[For more details: What is the difference between `import * as react from 'react'` vs `import react from 'react'`](https://stackoverflow.com/questions/54585763/what-is-the-difference-between-import-as-react-from-react-vs-import-react-fr)
