### PR TITLE
Remove invalid comma in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,5 @@
     "src/**/*.ts",
     "src/**/*.tsx"
   ],
-  "exclude": ["**/node_modules", "**/dist", "**/lib"],
+  "exclude": ["**/node_modules", "**/dist", "**/lib"]
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | 

#### What's in this Pull Request?

Removes an unnecessary/invalid comma from tsconfig.json that causes npm run serve to break.