### PR TITLE
Fix for ModernTaxonomyPicker infinite loop

### DIFF
--- a/docs/documentation/docs/controls/ModernTaxonomyPicker.md
+++ b/docs/documentation/docs/controls/ModernTaxonomyPicker.md
@@ -163,7 +163,7 @@ The ModernTaxonomyPicker control can be configured with the following properties
 | label | string | yes | Text displayed above the Taxonomy Picker. |
 | disabled | boolean | no | Specify if the control should be disabled. Default value is false. |
 | context | BaseComponentContext | yes | Context of the current web part or extension. |
-| initialValues | ITermInfo[] | no | Defines the terms selected by default. ITermInfo comes from PnP/PnPjs and can be imported with <br/>```import { ITermInfo } from '@pnp/sp/taxonomy';``` |
+| initialValues | ITermInfo[] | no | Defines the terms selected by default. This will only set the initial values and cannot be used to use the control in a controlled way. ITermInfo comes from PnP/PnPjs and can be imported with <br/>```import { ITermInfo } from '@pnp/sp/taxonomy';``` |
 | allowMultipleSelections | boolean | no | Defines if the user can select only one or multiple terms. Default value is false. |
 | termSetId | string | yes | The Id of the TermSet that you would like the Taxonomy Picker to select terms from. |
 | onChange | function | no |  Captures the event of when the terms in the picker has changed. |

--- a/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
+++ b/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
@@ -108,13 +108,13 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps): JSX.Ele
           // no-op;
         });
     }
-  }, [currentTermStoreInfo?.defaultLanguageTag, props.anchorTermId, props.context.pageContext, props.initialValues, props.termSetId, taxonomyService]);
+  }, []);
 
   React.useEffect(() => {
     if (props.onChange && initialLoadComplete.current) {
       props.onChange(selectedOptions);
     }
-  }, [props, selectedOptions]);
+  }, [selectedOptions]);
 
   function onOpenPanel(): void {
     if (props.disabled === true) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | mentioned in #1306 and #1308

#### What's in this Pull Request?
This PR fixes an issue introduced in #1261. The initialValues property was never meant to be used as a way to use the control in a controlled way. The control would need to be totally refactored to make it controlled. In that case another property would preferably be introduced, e.g. selectedItems. See for example the FluentUI [PeoplePicker](https://developer.microsoft.com/en-us/fluentui#/controls/web/peoplepicker) that has both a defaultSelectedItems property to use the control in an uncontrolled way and a selectedItems property to use the control in a controlled way.