### PR TITLE
FolderPicker: fix to get folders of other site.

### DIFF
--- a/src/controls/folderPicker/FolderPicker.tsx
+++ b/src/controls/folderPicker/FolderPicker.tsx
@@ -87,6 +87,7 @@ export class FolderPicker extends React.Component<IFolderPickerProps, IFolderPic
               defaultFolder={this.state.selectedFolder}
               onSelect={this._onFolderSelect}
               canCreateFolders={this.props.canCreateFolders}
+              siteAbsoluteUrl={this.props.siteAbsoluteUrl}
             />
           </div>
         </Panel>

--- a/src/controls/folderPicker/IFolderPickerProps.ts
+++ b/src/controls/folderPicker/IFolderPickerProps.ts
@@ -8,6 +8,11 @@ export interface IFolderPickerProps {
   context: BaseComponentContext;
 
   /**
+   * The absolute url of the target site. Only required if not the current site
+   */
+  siteAbsoluteUrl?: string;
+
+  /**
    * The label for the control
    */
   label: string;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1305

#### What's in this Pull Request?

Fix folderpicker to get folders of other site instead of the current context by adding a new property siteAbsoluteUrl and forwarding it to FolderExplorer. Fix #1305

Example of FolderPicker using siteAbsoluteUrl
![image](https://user-images.githubusercontent.com/47456098/199053102-e97310a2-31f5-43d1-b428-54b91e21ddf4.png)

```tsx
<FolderPicker context={this.props.context}
    rootFolder={{
        Name: 'Documents',
        ServerRelativeUrl: `/sites/dd2b7bc8-d667-4c63-b5ae-798f24287a77/Shared Documents`
    }}
    onSelect={this._onFolderSelect}
    label='Folder Picker'
    required={true}
    canCreateFolders={true}
    siteAbsoluteUrl="https://2zcny0.sharepoint.com/sites/dd2b7bc8-d667-4c63-b5ae-798f24287a77"
></FolderPicker>
```

Example of folderPicker without siteAbsoluteUrl

![image](https://user-images.githubusercontent.com/47456098/199055022-37ce023f-1245-43fd-821c-77dd9452cd4c.png)


```tsx
<FolderPicker context={this.props.context}
    rootFolder={{
        Name: 'Documents',
        ServerRelativeUrl: `${this.props.context.pageContext.web.serverRelativeUrl === '/' ? '' : this.props.context.pageContext.web.serverRelativeUrl}/Shared Documents`
    }}
    onSelect={this._onFolderSelect}
    label='Folder Picker'
    required={true}
    canCreateFolders={true}
></FolderPicker>
```
