### PR TITLE
Fix FileBrowser causing http 429, correct enum declaration implemented

### DIFF
--- a/src/controls/filePicker/controls/FileBrowser/IFileBrowserState.ts
+++ b/src/controls/filePicker/controls/FileBrowser/IFileBrowserState.ts
@@ -4,9 +4,9 @@ import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { IFilePickerResult } from "../../FilePicker.types";
 
 export enum LoadingState {
-  idle = 1,
-  loading = 2,
-  loadingNextPage
+  idle = 'idle',
+  loading = 'loading',
+  loadingNextPage = 'loadingNextPage'
 }
 
 export interface IFileBrowserState {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| Related issues?  | fixes #1350

#### What's in this Pull Request?

The condition checked for loading further items in the [_loadNextDataRequest-Method](https://github.com/pnp/sp-dev-fx-controls-react/blob/master/src/controls/filePicker/controls/FileBrowser/FileBrowser.tsx#L229) is always true because TypeScript Enums with numeric values cannot be tested as implemented in the code.
Changed to String Enum so the code works