### PR TITLE
FilePicker Issue - Site Tab - Many Document Libraries No Scrolling

### DIFF
--- a/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
+++ b/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
@@ -5,6 +5,7 @@ import { ISiteFilePickerTabState } from './ISiteFilePickerTabState';
 import { DocumentLibraryBrowser } from '../controls/DocumentLibraryBrowser/DocumentLibraryBrowser';
 import { FileBrowser } from '../controls/FileBrowser/FileBrowser';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/components/Button';
+import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Breadcrumb } from 'office-ui-fabric-react/lib/Breadcrumb';
 import { IFile, IFolder, ILibrary } from '../../../services/FileBrowserService.types';
 import { IFilePickerResult, FilePickerBreadcrumbItem } from '../FilePicker.types';
@@ -177,10 +178,14 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
         </div>
         <div className={styles.tabFiles}>
           {this.state.libraryAbsolutePath === undefined &&
-            <DocumentLibraryBrowser
-              fileBrowserService={this.props.fileBrowserService}
-              includePageLibraries={this.props.includePageLibraries}
-              onOpenLibrary={(selectedLibrary: ILibrary) => this._handleOpenLibrary(selectedLibrary, true)} />}
+            <div className={styles.scrollablePaneWrapper}>
+              <ScrollablePane>
+                <DocumentLibraryBrowser
+                  fileBrowserService={this.props.fileBrowserService}
+                  includePageLibraries={this.props.includePageLibraries}
+                  onOpenLibrary={(selectedLibrary: ILibrary) => this._handleOpenLibrary(selectedLibrary, true)} />
+              </ScrollablePane>
+            </div>}
           {this.state.libraryAbsolutePath !== undefined &&
             <FileBrowser
               onChange={(filePickerResults: IFilePickerResult[]) => this._handleSelectionChange(filePickerResults)}


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

'FilePicker' control, 'Sites' tab - when many document libraries exists in the site, the control would not scroll if they didn't fit in the layout - `<ScrollablePane />` added

Same issue as in the property controls (https://github.com/pnp/sp-dev-fx-property-controls/issues/525)

@joelfmrodrigues  -> As agreed