### PR TITLE
Filepicker breadcrumb null=>undefined #1368

### DIFF
--- a/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
+++ b/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
@@ -209,7 +209,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
     let { breadcrumbItems } = this.state;
     let breadcrumbClickedItemIndx = 0;
     // Site node clicked
-    if (node.libraryData === null && node.folderData === null) {
+    if (node.libraryData === undefined && node.folderData === undefined) {
       this.setState({
         libraryAbsolutePath: undefined,
         libraryPath: undefined,
@@ -217,13 +217,13 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
       });
     }
     // Check if it is folder item
-    else if (node.folderData !== null) {
+    else if (node.folderData !== undefined) {
       this._handleOpenFolder(node.folderData, false);
       // select which node has been clicked
       breadcrumbClickedItemIndx = findIndex(breadcrumbItems, item => item.folderData && item.folderData.absoluteUrl === node.key);
     }
     // Check if it is library node
-    else if (node.libraryData !== null) {
+    else if (node.libraryData !== undefined) {
       this._handleOpenLibrary(node.libraryData, false);
       // select which node has been clicked
       breadcrumbClickedItemIndx = findIndex(breadcrumbItems, item => item.libraryData && item.libraryData.serverRelativeUrl === node.key);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1368 

#### What's in this Pull Request?
Fixing an issue where breadcrumbs navigation wasn't working in a FilePicker component.

changing from
```typescript
if (node.libraryData === null && node.folderData === null) {
else if (node.folderData !== null) {
else if (node.libraryData !== null) {
```
to
```typescript
if (node.libraryData === undefined && node.folderData === undefined) {
else if (node.folderData !== undefined) {
else if (node.libraryData !== undefined) {
```
fixes the issue

My guess is that the bug was came from when updating to newer spfx version (where new eslint rules comaplains about using == instead of ===)
```typescript
undefined === null
//false
undefined == null
//true
```
