### PR TITLE
Fix site browser resize

### DIFF
--- a/src/controls/filePicker/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.tsx
+++ b/src/controls/filePicker/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.tsx
@@ -50,19 +50,19 @@ export class DocumentLibraryBrowser extends React.Component<IDocumentLibraryBrow
 
   public render(): React.ReactElement<IDocumentLibraryBrowserProps> {
 
-    const {lists, isLoading } = this.state;
+    const { lists, isLoading } = this.state;
 
     return (
       <div className={styles.documentLibraryBrowserContainer}>
-        { isLoading && <Spinner label='Caricamento...' /> }
-          <List
-            className={styles.filePickerFolderCardGrid}
-            items={lists}
-            getItemCountForPage={this._getItemCountForPage}
-            getPageHeight={this._getPageHeight}
-            renderedWindowsAhead={4}
-            onRenderCell={this._onRenderLibraryTile}
-          />
+        {isLoading && <Spinner label={strings.Loading} />}
+        <List
+          className={styles.filePickerFolderCardGrid}
+          items={lists}
+          getItemCountForPage={this._getItemCountForPage}
+          getPageHeight={this._getPageHeight}
+          renderedWindowsAhead={4}
+          onRenderCell={this._onRenderLibraryTile}
+        />
       </div>
     );
   }

--- a/src/controls/filePicker/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.tsx
+++ b/src/controls/filePicker/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.tsx
@@ -49,23 +49,20 @@ export class DocumentLibraryBrowser extends React.Component<IDocumentLibraryBrow
   }
 
   public render(): React.ReactElement<IDocumentLibraryBrowserProps> {
-    if (this.state.isLoading) {
-      return (<Spinner label={strings.Loading} />);
-    }
-    const libraries: ILibrary[] = this.state.lists;
+
+    const {lists, isLoading } = this.state;
 
     return (
       <div className={styles.documentLibraryBrowserContainer}>
-        <FocusZone>
+        { isLoading && <Spinner label='Caricamento...' /> }
           <List
             className={styles.filePickerFolderCardGrid}
-            items={libraries}
+            items={lists}
             getItemCountForPage={this._getItemCountForPage}
             getPageHeight={this._getPageHeight}
             renderedWindowsAhead={4}
             onRenderCell={this._onRenderLibraryTile}
           />
-        </FocusZone>
       </div>
     );
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | N.A.

#### What's in this Pull Request?

Once initialized, the DocumentLibraryBrowser component starts loading the list collection and displays a _Spinner_ control. After receiving the response from SharePoint, the React state was updated successfully but the browser doesn't recalculate the size of the items and so the list is displayed if you don't do a window resize. I redesigned the rendering logic of the component.