### PR TITLE
Use theme colors - fix dark mode

### DIFF
--- a/src/controls/filePicker/FilePicker.module.scss
+++ b/src/controls/filePicker/FilePicker.module.scss
@@ -42,7 +42,7 @@
   padding-bottom: 0px;
   padding-left: 15px;
   height: 36px;
-  color: $ms-color-neutralPrimary;
+  color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
   background-color: transparent;
   width: 100%;
   line-height: 36px;
@@ -73,8 +73,8 @@
   padding-bottom: 0px;
   padding-left: 15px;
   height: 36px;
-  color: $ms-color-themePrimary;
-  background-color: $ms-color-neutralLighter;
+  color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
+  background-color: "[theme:neutralLighter, default:#{$ms-color-neutralLighter}]";
   width: 100%;
   line-height: 36px;
   text-overflow: ellipsis;
@@ -118,7 +118,7 @@
 .nav {
   position: absolute;
   height: 100%;
-  color: $ms-color-neutralLighter;
+  color: "[theme:neutralLighter, default:#{$ms-color-neutralLighter}]";
 }
 
 [dir="ltr"] .nav {
@@ -134,13 +134,13 @@
   box-sizing: border-box;
   border-top-width: 40px;
   border-top-style: solid;
-  color: $ms-color-neutralLighter;
+  color: "[theme:neutralLighter, default:#{$ms-color-neutralLighter}]";
 }
 
 .tabHeaderContainer {
   display: inline-block;
   width: 100%;
-  color: $ms-color-neutralLighter;
+  color: "[theme:neutralLighter, default:#{$ms-color-neutralLighter}]";
   border-top: 40px solid;
 }
 
@@ -149,7 +149,7 @@
   padding: 22px 32px;
 }
 .breadcrumbNavItem {
-  color: $ms-color-neutralPrimary;
+  color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
   font-size: 24px;
   font-weight: 600;
   padding: 22px 8px 20px 0;
@@ -189,7 +189,7 @@
   -ms-flex-direction: column;
   flex-direction: column;
   width: 100%;
-  background-color: $ms-color-white;
+  background-color: "[theme:white, default:#{$ms-color-white}]";
   -ms-flex-negative: 0;
   flex-shrink: 0;
   z-index: 100;
@@ -232,7 +232,7 @@
 }
 
 .tabHeader {
-  color: $ms-color-neutralPrimary;
+  color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
   margin: 0;
   font-size: 24px;
   font-weight: 600;

--- a/src/controls/filePicker/MultipleUploadFilePickerTab/MultipleUploadFilePickerTab.module.scss
+++ b/src/controls/filePicker/MultipleUploadFilePickerTab/MultipleUploadFilePickerTab.module.scss
@@ -14,11 +14,11 @@
 }
 
 .localTabFilename {
-  color: $ms-color-neutralPrimary;
+  color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
 }
 
 .localTabLabel {
-  color: $ms-color-themePrimary;
+  color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
   cursor: pointer;
 }
 
@@ -33,7 +33,7 @@
 
 .localTabDragDropFile {
   // width: 100%;
-  border: 1px black dashed;
+  border: 1px "[theme:black, default:#{$ms-color-black}]" dashed;
   text-align: center;
   padding: 75px;
 }

--- a/src/controls/filePicker/RecentFilesTab/RecentFilesTab.module.scss
+++ b/src/controls/filePicker/RecentFilesTab/RecentFilesTab.module.scss
@@ -19,7 +19,7 @@
 .itemTile.isFile,
 .itemTile.isPhoto,
 .itemTile.isVideo {
-  background-color: $ms-color-neutralLighter;
+  background-color: "[theme:neutralLighter, default:#{$ms-color-neutralLighter}]";
 }
 
 .itemTile {
@@ -60,9 +60,9 @@
     top: 2px;
     bottom: 2px;
     border: 1px solid;
-    border-color: $ms-color-white;
-    -webkit-box-shadow: 0 0 0 2px $ms-color-neutralSecondaryAlt;
-    box-shadow: 0 0 0 2px $ms-color-neutralSecondaryAlt;
+    border-color: "[theme:white, default:#{$ms-color-white}]";
+    -webkit-box-shadow: 0 0 0 2px "[theme:neutralSecondaryAlt, default:#{$ms-color-neutralSecondaryAlt}]";
+    box-shadow: 0 0 0 2px "[theme:neutralSecondaryAlt, default:#{$ms-color-neutralSecondaryAlt}]";
   }
 }
 
@@ -79,13 +79,13 @@
 .itemTile.isFile .itemTileFileContainer {
   border-width: 1px;
   border-style: solid;
-  border-color: $ms-color-neutralLight;
+  border-color: "[theme:neutralLight, default:#{$ms-color-neutralLight}]";
 }
 
 .itemTileFile {
   .itemTileFileContainer {
     position: absolute;
-    background-color: $ms-color-neutralLighter;
+    background-color: "[theme:neutralLighter, default:#{$ms-color-neutralLighter}]";
     left: 0;
     right: 0;
     top: 0;
@@ -143,8 +143,8 @@
   right: 0;
   min-height: 20px;
   padding: 4px 8px 8px;
-  background-color: $ms-color-white;
-  color: $ms-color-neutralPrimary;
+  background-color: "[theme:white, default:#{$ms-color-white}]";
+  color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
   white-space: nowrap;
   text-overflow: ellipsis;
 }
@@ -152,7 +152,7 @@
   opacity: 0.95;
   border-top-width: 1px;
   border-top-style: solid;
-  border-top-color: $ms-color-neutralLight;
+  border-top-color: "[theme:neutralLight, default:#{$ms-color-neutralLight}]";
   min-height: 35px;
 }
 

--- a/src/controls/filePicker/UploadFilePickerTab/UploadFilePickerTab.module.scss
+++ b/src/controls/filePicker/UploadFilePickerTab/UploadFilePickerTab.module.scss
@@ -14,11 +14,11 @@
 }
 
 .localTabFilename {
-  color: $ms-color-neutralPrimary;
+  color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
 }
 
 .localTabLabel {
-  color: $ms-color-themePrimary;
+  color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
   cursor: pointer;
 }
 

--- a/src/controls/filePicker/WebSearchTab/WebSearchTab.module.scss
+++ b/src/controls/filePicker/WebSearchTab/WebSearchTab.module.scss
@@ -81,7 +81,7 @@
   top: 2px;
   bottom: 2px;
   box-sizing: border-box;
-  border: 1px solid $ms-color-white;
+  border: 1px solid "[theme:white, default:#{$ms-color-white}]";
 }
 
 .filePickerFolderCardSizer {
@@ -92,7 +92,7 @@
   width: 100%;
   left: 0;
   top: 0;
-  color: $ms-color-white;
+  color: "[theme:white, default:#{$ms-color-white}]";
   position: absolute;
   bottom: 0;
   font-size: 12px;
@@ -104,7 +104,7 @@
   height: 100%;
   width: 100%;
   top: 0;
-  color: $ms-color-white;
+  color: "[theme:white, default:#{$ms-color-white}]";
   padding: 10px;
   position: absolute;
   bottom: 0;
@@ -116,13 +116,13 @@
   font-weight: 600;
 
   &:hover {
-    color: $ms-color-neutralLight;
+    color: "[theme:neutralLight, default:#{$ms-color-neutralLight}]";
     background-color: rgba(0, 0, 0, 0.6);
   }
 
   &:active {
-    background-color: $ms-color-neutralTertiaryAlt;
-    color: $ms-color-neutralDark;
+    background-color: "[theme:neutralTertiaryAlt, default:#{$ms-color-neutralTertiaryAlt}]";
+    color: "[theme:neutralDark, default:#{$ms-color-neutralDark}]";
   }
 }
 
@@ -167,15 +167,15 @@
     top: 2px;
     bottom: 2px;
     border: 1px solid;
-    border-color: $ms-color-white;
-    -webkit-box-shadow: 0 0 0 2px $ms-color-neutralSecondaryAlt;
-    box-shadow: 0 0 0 2px $ms-color-neutralSecondaryAlt;
+    border-color: "[theme:white, default:#{$ms-color-white}]";
+    -webkit-box-shadow: 0 0 0 2px "[theme:neutralSecondaryAlt, default:#{$ms-color-neutralSecondaryAlt}]";
+    box-shadow: 0 0 0 2px "[theme:neutralSecondaryAlt, default:#{$ms-color-neutralSecondaryAlt}]";
   }
 }
 
 .bingTileContent {
   border: 1px solid;
-  border-color: $ms-color-white;
+  border-color: "[theme:white, default:#{$ms-color-white}]";
   width: 100%;
   height: 100%;
 }
@@ -187,8 +187,8 @@
   top: 2px;
   right: 2px;
   bottom: 2px;
-  -webkit-box-shadow: 0 0 0 2px $ms-color-neutralTertiaryAlt;
-  box-shadow: 0 0 0 2px $ms-color-neutralTertiaryAlt;
+  -webkit-box-shadow: 0 0 0 2px "[theme:neutralTertiaryAlt, default:#{$ms-color-neutralTertiaryAlt}]";
+  box-shadow: 0 0 0 2px "[theme:neutralTertiaryAlt, default:#{$ms-color-neutralTertiaryAlt}]";
   outline: 1px solid transparent;
 }
 
@@ -213,8 +213,8 @@
   left: 0;
   right: 0;
   padding: 4px 8px 8px;
-  background-color: $ms-color-white;
-  color: $ms-color-neutralPrimary;
+  background-color: "[theme:white, default:#{$ms-color-white}]";
+  color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
   white-space: nowrap;
   text-overflow: ellipsis;
   opacity: 0.95;

--- a/src/controls/filePicker/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.module.scss
+++ b/src/controls/filePicker/controls/DocumentLibraryBrowser/DocumentLibraryBrowser.module.scss
@@ -41,7 +41,7 @@
   top: 2px;
   bottom: 2px;
   box-sizing: border-box;
-  border: 1px solid $ms-color-white;
+  border: 1px solid "[theme:white, default:#{$ms-color-white}]";
 }
 
 .filePickerFolderCardSizer {
@@ -52,7 +52,7 @@
   width: 100%;
   left: 0;
   top: 0;
-  color: $ms-color-white;
+  color: "[theme:white, default:#{$ms-color-white}]";
   position: absolute;
   bottom: 0;
   font-size: 12px;
@@ -60,11 +60,11 @@
 }
 
 .filePickerFolderCardLabel {
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: "[theme:neutralLight, default:#{$ms-color-neutralLight}]";
   height: 100%;
   width: 100%;
   top: 0;
-  color: $ms-color-white;
+  color: "[theme:black, default:#{$ms-color-black}]";
   padding: 10px;
   position: absolute;
   bottom: 0;
@@ -81,13 +81,13 @@
   }
 
   &:hover {
-    color: $ms-color-neutralLight;
-    background-color: rgba(0, 0, 0, 0.6);
+    color: "[theme:black, default:#{$ms-color-black}]";
+    background-color: "[theme:neutralLighter, default:#{$ms-color-neutralLighter}]";
   }
 
   &:active {
-    background-color: $ms-color-neutralTertiaryAlt;
-    color: $ms-color-neutralDark;
+    color: "[theme:black, default:#{$ms-color-black}]";
+    background-color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
   }
 }
 

--- a/src/controls/filePicker/controls/FolderTile/FolderTile.module.scss
+++ b/src/controls/filePicker/controls/FolderTile/FolderTile.module.scss
@@ -77,7 +77,7 @@
   max-height: 100%;
   -webkit-box-shadow: 0 1px 3px 2px rgba(1, 1, 0, 0.2);
   box-shadow: 0 1px 3px 2px rgba(1, 1, 0, 0.2);
-  background-color: $ms-color-white;
+  background-color: "[theme:white, default:#{$ms-color-white}]";
   min-width: 32px;
   min-height: 32px;
 }

--- a/src/controls/richText/RichText.module.scss
+++ b/src/controls/richText/RichText.module.scss
@@ -94,7 +94,7 @@
   font-size: 8px;
   speak: none;
   top: 50%;
-  color: $ms-color-neutralLighterAlt;
+  color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
 }
 
 .toolbarSubmenuDisplayButton {
@@ -104,7 +104,7 @@
 :global {
   .ql-toolbar {
     background-color: transparent;
-    color: $ms-color-neutralLighterAlt;
+    color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
     border: none;
     display: none;
 
@@ -117,31 +117,31 @@
     }
 
     .ms-Button {
-      background-color: $ms-color-neutralPrimary;
-      color: $ms-color-neutralLighterAlt !important;
+      background-color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
+      color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]" !important;
 
       &:hover {
-        background-color: $ms-color-neutralSecondaryAlt;
-        color: $ms-color-neutralLighterAlt;
+        background-color: "[theme:neutralTertiary, default:#{$ms-color-neutralTertiary}]";
+        color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
       }
 
       &:focus {
-        border: 1px solid $ms-color-neutralLighterAlt;
+        border: 1px solid "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
         outline: 0;
-        color: $ms-color-neutralLighterAlt;
+        color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
       }
 
       &:active {
-        color: $ms-color-neutralLighterAlt;
+        color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
       }
 
       &.is-checked {
-        background-color: $ms-color-themePrimary !important;
+        background-color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]" !important;
       }
     }
     .ms-Dropdown-title {
-      background-color: $ms-color-neutralPrimary;
-      color: $ms-color-neutralLighterAlt !important;
+      background-color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
+      color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]" !important;
       border: none;
       min-height: 34px;
       padding-bottom: 0px;
@@ -151,20 +151,21 @@
       -webkit-transition: all 0.3s;
       transition: all 0.3s;
       -webkit-transition-property: background-color, color;
+      border-radius: 0;
 
       &:hover {
-        background-color: $ms-color-neutralSecondaryAlt;
-        color: $ms-color-neutralLighterAlt;
+        background-color: "[theme:neutralTertiary, default:#{$ms-color-neutralTertiary}]";
+        color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
       }
 
       &:focus {
-        border: 1px solid $ms-color-neutralLighterAlt;
+        border: 1px solid "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
         outline: 0;
-        color: $ms-color-neutralLighterAlt;
+        color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
       }
 
       &:active {
-        color: $ms-color-neutralLighterAlt;
+        color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
       }
     }
 
@@ -176,14 +177,15 @@
 
   .ql-snow.ql-toolbar button,
   .ql-snow .ql-toolbar button {
-    background-color: $ms-color-neutralPrimary;
-    color: $ms-color-neutralLighterAlt;
+    background-color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
+    color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]";
     font-size: 14px;
     min-width: 34px;
     height: 34px;
     padding-top: 4px;
     padding-left: 8px;
     padding-right: 8px;
+    border-radius: 0;
   }
 
   .ql-toolbar.ql-snow {
@@ -218,7 +220,7 @@
   .ql-active .ql-editor:hover {
     border-width: 1px;
     border-style: solid;
-    border-color: $ms-color-neutralTertiary;
+    border-color: "[theme:neutralTertiary, default:#{$ms-color-neutralTertiary}]";
   }
 
   .ql-active .ql-editor:focus,
@@ -226,7 +228,7 @@
   .ql-active .ql-editor:active:hover {
     border-width: 1px;
     border-style: solid;
-    border-color: $ms-color-themePrimary;
+    border-color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
   }
 
   .ql-active .ql-toolbar {
@@ -240,7 +242,7 @@
   }
 
   .ql-snow .ql-editor, .ql-editor{
-    border: 1px solid transparent;
+    // border: 1px solid transparent;
     padding-left: 10px;
     padding-right: 10px;
     padding-top: 8px;
@@ -274,14 +276,14 @@
     p,
     ul {
       -webkit-font-smoothing: antialiased;
-      color: $ms-color-neutralPrimary;
+      color: "[theme:black, default:#{$ms-color-black}]";
       line-height: 1.3;
-      margin: 0 0 16px;
+      // margin: 0 0 16px;
       word-wrap: break-word;
     }
 
     blockquote {
-      border-bottom-color: $ms-color-neutralTertiaryAlt;
+      border-bottom-color: "[theme:neutralTertiaryAlt, default:#{$ms-color-neutralTertiaryAlt}]";
       border-bottom-style: solid;
       border-bottom-width: 1px;
       border-left-style: none;
@@ -290,10 +292,10 @@
       border-right-style: none;
       border-right-width: 0;
       border-right-color: transparent;
-      border-top-color: $ms-color-neutralTertiaryAlt;
+      border-top-color: "[theme:neutralTertiaryAlt, default:#{$ms-color-neutralTertiaryAlt}]";
       border-top-style: solid;
       border-top-width: 1px;
-      color: $ms-color-neutralSecondaryAlt;
+      color: "[theme:neutralSecondaryAlt, default:#{$ms-color-neutralSecondaryAlt}]";
       font-size: 24px;
       font-style: italic;
       font-weight: 100;
@@ -372,31 +374,68 @@
 
   .ql-editor.ql-blank::before {
     font-style: normal;
-    color: $ms-color-neutralTertiary;
+    color: "[theme:neutralTertiary, default:#{$ms-color-neutralTertiary}]";
     font-size: 17px;
     font-weight: 300;
     line-height: 1.3;
   }
 
+  // correct border/hover/active border, same as with other controls, no jumping
+  .quill {
+    .ql-editor {
+      border-width: 1px;
+      border-style: solid;
+      border-color: "[theme:neutralTertiary, default:#{$ms-color-neutralTertiary}]";
+      &:hover {
+        border-color: "[theme:neutralDark, default:#{$ms-color-neutralDark}]";
+      }
+      &:active::after, &:active:focus::after, &:active:hover::after, &:focus::after {
+        content: "";
+        pointer-events: none;
+        position: absolute;
+        border-style: solid;
+        border-width: 2px;
+        inset: -1px;
+        border-color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
+        border-radius: 2px;
+      }
+    }
+  }
+
+  // hyperlin color on dark theme
+  .ql-editor {
+    a {
+      color: "[theme:themePrimary, default: #{$ms-color-themePrimary}]";
+      &:hover {
+        color: "[theme:themeDarker, default: #{$ms-color-themeDarker}]";
+      }
+    }
+  }
+
+  .ql-editor ol li:not(.ql-direction-rtl),
+  .ql-editor ul li:not(.ql-direction-rtl) {
+    padding-left: 0;
+  }
+
   div#DropDownStyles-list, div#DropDownAlign-list, div#DropDownLists-list {
     .ms-Dropdown-item {
-      background-color: $ms-color-neutralPrimary !important;
-      color: $ms-color-neutralLighterAlt !important;
+      background-color: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]" !important;
+      color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]" !important;
       -webkit-transition: all 0.3s;
       transition: all 0.3s;
       -webkit-transition-property: background-color, color;
     }
 
     .ms-Dropdown-item:hover {
-      background-color: $ms-color-neutralSecondaryAlt !important;
-      color: $ms-color-neutralLighterAlt !important;
+      background-color: "[theme:neutralTertiary, default:#{$ms-color-neutralTertiary}]" !important;
+      color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]" !important;
       cursor: pointer;
     }
 
     .ms-Dropdown-item.is-selected,
     .ms-Dropdown-item.is-selected:hover {
-      background-color: $ms-color-themePrimary !important;
-      color: $ms-color-neutralLighterAlt !important;
+      background-color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]" !important;
+      color: "[theme:neutralLighterAlt, default:#{$ms-color-neutralLighterAlt}]" !important;
     }
   }
 }

--- a/src/controls/richText/RichTextPropertyPane.module.scss
+++ b/src/controls/richText/RichTextPropertyPane.module.scss
@@ -1,14 +1,14 @@
 @import '~office-ui-fabric-react/dist/sass/References.scss';
 
 :export {
-  NeutralPrimary: $ms-color-neutralPrimary;
+  NeutralPrimary: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
 }
 
 .richTextPropertyPane {
   .formattingPaneTitle {
     background-attachment: scroll;
     background-clip: border-box;
-    background-color: $ms-color-neutralPrimaryAlt;
+    background-color: "[theme:neutralDark, default:#{$ms-color-neutralDark}]";
     background-image: none;
     background-origin: padding-box;
     background-position-x: 0%;
@@ -20,7 +20,7 @@
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 10px;
-    color: $ms-color-white;
+    color: "[theme:white, default:#{$ms-color-white}]";
     font-family: "Segoe UI Web (West European)", Segoe UI, -apple-system,
       BlinkMacSystemFont, Roboto, Helvetica Neue, sans-serif;
     font-size: 21px;
@@ -45,7 +45,7 @@
     margin-left: auto;
     background-color: transparent;
     border: none;
-    color: #fff;
+    color: "[theme:white, default:#{$ms-color-white}]";
     cursor: pointer;
     font-size: 20px;
     padding: 0;
@@ -72,22 +72,22 @@
   padding: 0;
 
   &:hover {
-    background-color: $ms-color-neutralLight;
-    color: $ms-color-themePrimary;
+    background-color: "[theme:neutralLight, default:#{$ms-color-neutralLight}]";
+    color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
   }
 
   &:global(.is-checked) {
-    color: $ms-color-themePrimary;
+    color: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
   }
 
   &:global(.is-disabled) {
-    background-color: #fff;
+    background-color: "[theme:white, default:#{$ms-color-white}]";
   }
 }
 
 .propertyPaneGroupField {
   padding-top: 4px;
-  color: #333333;
+  color: "[theme:neutralPrimaryAlt, default:#{$ms-color-neutralPrimaryAlt}]";
   word-wrap: break-word;
 }
 
@@ -95,7 +95,7 @@
   font-size: 14px;
   font-weight: 400;
   font-weight: 600;
-  color: #333333;
+  color: "[theme:neutralPrimaryAlt, default:#{$ms-color-neutralPrimaryAlt}]";
   padding-right: 0;
   // padding-left: 20px;
   text-align: left;

--- a/src/controls/richText/RteColorPicker.module.scss
+++ b/src/controls/richText/RteColorPicker.module.scss
@@ -1,23 +1,23 @@
 @import '~office-ui-fabric-react/dist/sass/References.scss';
 
 :export {
-  ThemeColorDarker: $ms-color-themeDarker;
-  ThemeColorDark: $ms-color-themeDark;
-  ThemeColorDarkAlt: $ms-color-themeDarkAlt;
-  ThemeColorPrimary: $ms-color-themePrimary;
-  ThemeColorSecondary: $ms-color-themeSecondary;
-  ThemeColorTertiary: $ms-color-themeTertiary;
-  ThemeColorNeutralSecondary:$ms-color-neutralSecondary;
-  ThemeColorNeutralPrimaryAlt: $ms-color-neutralPrimaryAlt;
-  ThemeColorNeutralPrimary: $ms-color-neutralPrimary;
-  ThemeColorNeutralDark:$ms-color-neutralDark
+  ThemeColorDarker: "[theme:themeDarker, default:#{$ms-color-themeDarker}]";
+  ThemeColorDark: "[theme:themeDark, default:#{$ms-color-themeDark}]";
+  ThemeColorDarkAlt: "[theme:themeDarkAlt, default:#{$ms-color-themeDarkAlt}]";
+  ThemeColorPrimary: "[theme:themePrimary, default:#{$ms-color-themePrimary}]";
+  ThemeColorSecondary: "[theme:themeSecondary, default:#{$ms-color-themeSecondary}]";
+  ThemeColorTertiary: "[theme:neutralTertiary, default:#{$ms-color-neutralTertiary}]";
+  ThemeColorNeutralSecondary:"[theme:neutralSecondary, default:#{$ms-color-neutralSecondary}]";
+  ThemeColorNeutralPrimaryAlt: "[theme:neutralPrimaryAlt, default:#{$ms-color-neutralPrimaryAlt}]";
+  ThemeColorNeutralPrimary: "[theme:neutralPrimary, default:#{$ms-color-neutralPrimary}]";
+  ThemeColorNeutralDark:"[theme:neutralDark, default:#{$ms-color-neutralDark}]"
 }
 
 .colorPickerButton {
   background: 0 0;
   padding-left: 4px;
   padding-right: 12px;
-  background-color: #ffffff;
+  background-color: "[theme: white, default: #{$ms-color-white}]";
 }
 
 .previewSvg {
@@ -25,7 +25,7 @@
   height: 20px;
 
   &.border {
-    border: 1px solid #000;
+    border: 1px solid "[theme: black, default: #{$ms-color-black}]";
   }
 }
 
@@ -47,7 +47,7 @@
 .pickerCallout {
   width: 166px;
   &:global(.ms-Callout-main) {
-    background-color: rgb(255, 255, 255);
+    background-color: "[theme:white, default: #{$ms-color-white}]";
     overflow-x: hidden;
     overflow-y: auto;
     position: relative;
@@ -62,7 +62,7 @@
   }
 
   &.border {
-    border: 1px solid #000;
+    border: 1px solid "[theme:black, default: #{$ms-color-black}]";
   }
 
   &.fillDefaultColor {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1132, #669

#### What's in this Pull Request?

Replaced hardcoded colors with theme-aware colors.
Fixed the border style for richEdit (to look the same as all other controls in all states). 
Only style changes (scss)

Affected controls: filePicker, richEdit

below screenshots of changes for two themes ("Dark Blue" and "Light Red")

### dark mode (blue)

rich edit area 

existing
![image](https://user-images.githubusercontent.com/528366/220570621-7c65f68a-2dcd-46a4-b9a7-114f5791cccf.png)
fixed
![image](https://user-images.githubusercontent.com/528366/220570642-a98f0cf8-6f02-4e93-a1c5-3a3f614514a5.png)

rich edit property pane

existing
![image](https://user-images.githubusercontent.com/528366/220570665-7603fdd2-b2c9-4f73-a908-040deb0232d9.png)
fixed
![image](https://user-images.githubusercontent.com/528366/220570679-3ac56559-26a5-4a07-aa42-1e00db8db951.png)

existing
![image](https://user-images.githubusercontent.com/528366/220580234-03cf14c3-b5dd-4718-9d40-76126d2add9b.png)
fixed
![image](https://user-images.githubusercontent.com/528366/220570710-bc8dd93d-deea-4c17-80e8-7cfd1050589d.png)

### light mode (red)

existing
![image](https://user-images.githubusercontent.com/528366/220570465-bb492c2e-f134-4f9f-ba72-1e2f8d9f3c76.png)
fixed
![image](https://user-images.githubusercontent.com/528366/220570503-c59a9884-d27d-400e-a130-4b8e181c8fc5.png)

existing
![image](https://user-images.githubusercontent.com/528366/220570523-aa6da1b4-e3a3-4e90-9887-d14af74c9d07.png)
fixed
![image](https://user-images.githubusercontent.com/528366/220570542-9e430723-e040-4896-87e7-fb898165b15c.png)

existing
![image](https://user-images.githubusercontent.com/528366/220570564-3cefcb45-2a6f-4664-9a14-d6311ac3de38.png)
fixed
![image](https://user-images.githubusercontent.com/528366/220570588-2b0b6c62-de32-4d83-be92-57625df19a7f.png)
