### PR TITLE
Update ComboBoxListItemPicker.md

### DIFF
--- a/docs/documentation/docs/controls/ComboBoxListItemPicker.md
+++ b/docs/documentation/docs/controls/ComboBoxListItemPicker.md
@@ -40,7 +40,7 @@ import { ComboBoxListItemPicker } from '@pnp/spfx-controls-react/lib/ListItemPic
                         columnInternalName='Title'
                         keyColumnInternalName='Id'
                         filter="Title eq 'SPFx'"
-                        defaultSelectedItems=[{Id: 2, Title:"Test"}]
+                        defaultSelectedItems={[{Id: 2, Title:"Test"}]}
                         onSelectedItem={this.onSelectedItem}
                         webUrl={this.context.pageContext.web.absoluteUrl}
                         spHttpClient={this.context.spHttpClient} />


### PR DESCRIPTION
When passing defaultSelectedItems prop you need to have it wrapped in {} to work.

| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]

#### What's in this Pull Request?

Updating the documentation for ComboBoxListItemPicker, for the defaultSelectedItems props when you are passing an object.
