### PR TITLE
Fixes DynamicForm trying to load TaxonomyFields with wrong display name. Closes #1422

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -426,7 +426,7 @@ export class DynamicForm extends React.Component<IDynamicFormProps, IDynamicForm
               defaultValue = [];
             }
           } else if (fieldType === "TaxonomyFieldTypeMulti") {
-            const response = await this._spService.getTaxonomyFieldInternalName(this.props.listId, field.InternalName, this.webURL);
+            const response = await this._spService.getTaxonomyFieldInternalName(this.props.listId, field.TextField, this.webURL);
             hiddenName = response.value;
             termSetId = field.TermSetId;
             anchorId = field.AnchorId;

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -578,10 +578,10 @@ export default class SPService implements ISPService {
     }
   }
 
-  public async getTaxonomyFieldInternalName(listId: string, fieldName: string, webUrl?: string): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
+  public async getTaxonomyFieldInternalName(listId: string, fieldId: string, webUrl?: string): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/Fields/getByInternalNameOrTitle('${fieldName}_0')/InternalName?@listId=guid'${encodeURIComponent(listId)}'`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/Fields/getById(guid'${fieldId}')/InternalName?@listId=guid'${encodeURIComponent(listId)}'`;
 
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1422

#### What's in this Pull Request?

Fixes an issue with Taxonomy Fields concerning the relation between Taxonomy Fields and their corresponding note fields. The corresponding note field internal name was retrieved by assuming that the Display Name of that note field was equal to the internal name of the Taxonomy field and `_0`.

**So for example:**
If the taxonomy field has an internal fieldname called `Project`, the display name of the note field was inferred to be `Project_0`. This is actually a correct assumption in most cases. When creating a Column using the SharePoint UI for example.
But there are scenario's when this is incorrect. For example when fields are provisioned using automated solutions, it's possible for these field titles to have received different values.

It's better to retrieve the field by Id. And this ID is also present in the details of the field in the form of the `TextField` property. 

