### PR TITLE
`ListItemAttachments` : FIX: Cannot download items when it has a ilegal character 

### DIFF
--- a/src/controls/listItemAttachments/ListItemAttachments.tsx
+++ b/src/controls/listItemAttachments/ListItemAttachments.tsx
@@ -274,8 +274,8 @@ export class ListItemAttachments extends React.Component<IListItemAttachmentsPro
                     directionalHint={DirectionalHint.rightCenter}>
 
                     <DocumentCard
-                      onClickHref={!openAttachmentsInNewWindow && `${file.ServerRelativeUrl}?web=1`}
-                      onClick={openAttachmentsInNewWindow && (() => window.open(`${file.ServerRelativeUrl}?web=1`, "_blank"))} // JJ - 20200613 - needed to support Microsoft Teams
+                      onClickHref={!openAttachmentsInNewWindow && `${encodeURIComponent(file.ServerRelativeUrl)}?web=1`}
+                      onClick={openAttachmentsInNewWindow && (() => window.open(`${encodeURIComponent(file.ServerRelativeUrl)}?web=1`, "_blank"))} // JJ - 20200613 - needed to support Microsoft Teams
                       className={styles.documentCard}>
                       <DocumentCardPreview previewImages={[previewImage]} />
                       <Label className={styles.fileLabel}>{fileName}</Label>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Encode URI to fix the issue of file download when it has URL reserved characters such as "#"

Reported Issue #1484 