### PR TITLE
FolderExplorer -FolderExplorer doesn't explore folders with ' in the name

### DIFF
--- a/src/services/FolderExplorerService.ts
+++ b/src/services/FolderExplorerService.ts
@@ -73,7 +73,7 @@ export class FolderExplorerService implements IFolderExplorerService {
     let results: IFolder[] = [];
     try {
       const web = Web(webAbsoluteUrl);
-      folderRelativeUrl = folderRelativeUrl.replace(/'/ig, "''");
+      //folderRelativeUrl = folderRelativeUrl.replace(/'/ig, "''");
       const foldersResult: IFolder[] = await web.getFolderByServerRelativePath(folderRelativeUrl).folders.select('Name', 'ServerRelativeUrl').orderBy(orderby, orderAscending).get();
       results = foldersResult.filter(f => f.Name !== "Forms");
     } catch (error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1491

#### What's in this Pull Request?

Fixed FolderExplorer to explore folders with ' in the name. The issue was reported that if you try to explore a folder with the char ' contained in the name, the folder explorer is unable to fetch the subfolders in it. 

Below is the screen from the Document library
![image](https://user-images.githubusercontent.com/47456098/229195170-dcf2614d-21e3-42b5-b3ed-a64ca453857c.png)

Below is the observed behaviour while exploring folders using FolderExplorer
![image](https://user-images.githubusercontent.com/47456098/229195308-2b80d61b-538d-4aa0-af24-d808197fb675.png)

#### Solution
The method **_getFolders**  in FolderExplorerService.ts, ```typescript folderRelativeUrl = folderRelativeUrl.replace(/'/ig, "''"); ``` is  replacing this char ' to '', hence the folder explorer is not able to show any subfolders from the folder (Snippet as below)

```typescript
  /**
   * Get folders within a given library or sub folder
   * @param webAbsoluteUrl - the url of the target site
   * @param folderRelativeUrl - the relative url of the folder
   */
  private _getFolders = async (webAbsoluteUrl: string, folderRelativeUrl: string, orderby: string, orderAscending: boolean): Promise<IFolder[]> => {
    let results: IFolder[] = [];
    try {
      const web = Web(webAbsoluteUrl);
      folderRelativeUrl = folderRelativeUrl.replace(/'/ig, "''");
      const foldersResult: IFolder[] = await web.getFolderByServerRelativePath(folderRelativeUrl).folders.select('Name', 'ServerRelativeUrl').orderBy(orderby, orderAscending).get();
      results = foldersResult.filter(f => f.Name !== "Forms");
    } catch (error) {
      console.error('Error loading folders', error);
    }
    return results;
  }
```

By commenting ```typescript folderRelativeUrl = folderRelativeUrl.replace(/'/ig, "''"); ```, we are able to fetch the subfolders from the specific folder with char ' in the name (As below)

```typescript 
  /**
   * Get folders within a given library or sub folder
   * @param webAbsoluteUrl - the url of the target site
   * @param folderRelativeUrl - the relative url of the folder
   */
  private _getFolders = async (webAbsoluteUrl: string, folderRelativeUrl: string, orderby: string, orderAscending: boolean): Promise<IFolder[]> => {
    let results: IFolder[] = [];
    try {
      const web = Web(webAbsoluteUrl);
      //folderRelativeUrl = folderRelativeUrl.replace(/'/ig, "''");
      const foldersResult: IFolder[] = await web.getFolderByServerRelativePath(folderRelativeUrl).folders.select('Name', 'ServerRelativeUrl').orderBy(orderby, orderAscending).get();
      results = foldersResult.filter(f => f.Name !== "Forms");
    } catch (error) {
      console.error('Error loading folders', error);
    }
    return results;
  }
 ```

Below is the screen from Document library
![image](https://user-images.githubusercontent.com/47456098/229197813-17d7632b-7a9d-4c03-96ed-cc9fe8761362.png)

![image](https://user-images.githubusercontent.com/47456098/229198276-cefb2fc8-4120-4d1a-9123-670da086896a.png)


Below is the screen while using FolderExplorer
![image](https://user-images.githubusercontent.com/47456098/229197933-5a7d965c-17bc-4229-ab0a-67653759682d.png)

Below is the screen while fetching the subfolders from the Folder with the char ' in the name
![image](https://user-images.githubusercontent.com/47456098/229198084-18d8afd5-7b2b-41e5-bc1a-47184bd4190d.png)

 


