### PR TITLE
Changed react import to fix "cannot be used as a JSX component" error

### DIFF
--- a/src/controls/fieldPicker/FieldPicker.tsx
+++ b/src/controls/fieldPicker/FieldPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { Dropdown, IDropdownOption, IDropdownProps } from 'office-ui-fabric-react/lib/Dropdown';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -1516,6 +1516,18 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
                   onSelectedItem={this.listItemPickerDataSelected} />
 
               </div>
+
+              <div className="ms-font-m">Field picker tester:
+                <FieldPicker 
+                  context={this.props.context}
+                  label={'Select a field'}
+                  listId={this.state.selectedList}
+                  onSelectionChanged={(fields) => {              
+                    console.log(fields);
+                  }}
+                />
+              </div>
+
               <div>Icon Picker</div>
               <div>
                 <IconPicker
@@ -2428,18 +2440,6 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
               />
             </Stack>
           </EnhancedThemeProvider>
-        </div>
-
-        <div>
-          <h3>Field Picker</h3>
-          <FieldPicker 
-            context={this.props.context}
-            label={'Select a field'}
-            listId={'07890a2b-10f1-47dd-a899-cc60ca461d51'}
-            onSelectionChanged={(fields) => {              
-              console.log(fields);
-            }}
-          />
         </div>
       </div>
     );

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -192,6 +192,7 @@ import { ModernAudio, ModernAudioLabelPosition } from "../../../ModernAudio";
 import { SPTaxonomyService, TaxonomyTree } from "../../../ModernTaxonomyPicker";
 import { TestControl } from "./TestControl";
 import { UploadFiles } from "../../../controls/uploadFiles";
+import { FieldPicker } from "../../../FieldPicker";
 
 // Used to render document card
 /**
@@ -2429,6 +2430,17 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           </EnhancedThemeProvider>
         </div>
 
+        <div>
+          <h3>Field Picker</h3>
+          <FieldPicker 
+            context={this.props.context}
+            label={'Select a field'}
+            listId={'07890a2b-10f1-47dd-a899-cc60ca461d51'}
+            onSelectionChanged={(fields) => {              
+              console.log(fields);
+            }}
+          />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  |

#### What's in this Pull Request?

Changed React import in FieldPicker to "import * as React from 'react' " to prevent " 'FieldPicker' cannot be used as a JSX component"-error that appears in some projects

