### PR TITLE
Update SPServices.ts

### DIFF
--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -528,7 +528,7 @@ export default class SPService implements ISPService {
   public async getLookupValue(listId: string, listItemID: number, fieldName: string, lookupFieldName: string | undefined, webUrl?: string): Promise<any[]> { // eslint-disable-line @typescript-eslint/no-explicit-any
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})/?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/Title&$expand=${fieldName}`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/Title,${fieldName}/${lookupFieldName}&$expand=${fieldName}`;
 
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {
@@ -548,7 +548,7 @@ export default class SPService implements ISPService {
   public async getLookupValues(listId: string, listItemID: number, fieldName: string, lookupFieldName: string | undefined, webUrl?: string): Promise<any[]> { // eslint-disable-line @typescript-eslint/no-explicit-any
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/Title&$expand=${fieldName}`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/Title,${fieldName}/${lookupFieldName}&$expand=${fieldName}`;
 
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {


### PR DESCRIPTION
Hello I found the problem of retrieving lookup values;

${fieldName}/${lookupFieldName} is missing from the URL api 

Can you fix it in the two functions getlookupvalues line 551 and getlookupvalue Line 531(file SPService.ts)

 The value in both functions is identical as follows:
 
       const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${listItemID})?@listId=guid'${encodeURIComponent(listId)}'&$select=${fieldName}/ID,${fieldName}/Title,${fieldName}/${lookupFieldName}&$expand=${fieldName}`;

I’ve already tested it 

Thank you for your understanding 
I hope there will be commit of this patch in the next few days 

Cordially
Zied FEHRI

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.


#### Guidance
- *You can delete this section when you are submitting the pull request.* 
- *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
- *Please target your PR to **dev** branch.*
