### PR TITLE
Fix- Issue 1421- PeoplePicker Control - Shows wrong value in Dynamic Form when null is provided & Issue 1578 - DynamicForm - Error on save when clearing person from Person or Group field and leaving it blank.

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -260,7 +260,7 @@ export class DynamicForm extends React.Component<
               .map((term) => `-1#;${term.name}|${term.key};`)
               .join("#");
           } else if (fieldType === "User") {
-            objects[`${columnInternalName}Id`] = val.newValue;
+            objects[`${columnInternalName}Id`] = val.newValue.length === 0 ? null : val.newValue;
           } else if (fieldType === "Choice") {
             objects[columnInternalName] = val.newValue.key;
           } else if (fieldType === "MultiChoice") {
@@ -269,7 +269,7 @@ export class DynamicForm extends React.Component<
             objects[columnInternalName] = JSON.stringify(val.newValue);
           } else if (fieldType === "UserMulti") {
             objects[`${columnInternalName}Id`] = {
-              results: val.newValue.lenght === 0 ? null : val.newValue,
+              results: val.newValue.length === 0 ? null : val.newValue,
             };
           } else if (fieldType === "Thumbnail") {
             if (additionalData) {

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -646,7 +646,7 @@ export default class SPService implements ISPService {
         }
       }
 
-      return null;
+      return [];
     } catch (error) {
       console.dir(error);
       return Promise.reject(error);

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -610,7 +610,11 @@ export default class SPService implements ISPService {
           const emails = [];
           result[fieldName].forEach(element => {
             const loginNameWithoutClaimsToken = element.Name.split("|").pop();
-            emails.push(loginNameWithoutClaimsToken + "/" + element.Title);
+            if(!loginNameWithoutClaimsToken.toLowerCase().includes('null')){
+              if(!element.Title.toLowerCase().includes('null')){
+                emails.push(loginNameWithoutClaimsToken + "/" + element.Title);
+              }
+            }
           });
           return emails;
         }
@@ -634,7 +638,11 @@ export default class SPService implements ISPService {
         if (result && result[fieldName]) {
           const element = result[fieldName]
           const loginNameWithoutClaimsToken = element.Name.split("|").pop();
-          return loginNameWithoutClaimsToken + "/" + element.Title;
+          if(!loginNameWithoutClaimsToken.toLowerCase().includes('null')){
+            if(!element.Title.toLowerCase().includes('null')){
+              return loginNameWithoutClaimsToken + "/" + element.Title;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1421 #1578 

#### What's in this Pull Request?
Fixing the issue 1421, Validating the ```Null``` in the user's name or email. 
Fixing issue 1578, Error on save when clearing person from Person or Group field and leaving it blank.

#### Solution for Issue #1421 
I have created a few users in my tenant, with the below mentioned names and email's

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/075d8752-2bd1-4d01-a06c-bc8b1d25cda7)

Added two columns in my test list, one as multi user, and single user respectively, and added the users to the list item as below.
![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/72ad2d7f-466d-4f00-bdc4-3f69a9e56c82)

I have also added extra validation at ```SPService.ts``` for the methods, ```getUsersUPNFromFieldValue``` & ```getUserUPNFromFieldValue``` to get the output as below.

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/61911820-bcdf-4e85-825a-652d00dcfad9)

#### Solution for Issue #1578
When the user is updating the people picker column, for a single user, Dynamic form is throwing error while saving the list item. The issue occurs at method ```onSubmitClick``` 

The object formed with an empty user and is being submitted to update the item 

```
          else if (fieldType === "User") {
            objects[`${columnInternalName}Id`] = val.newValue;
          }             
```

And the error is caught here, 

```
let newETag: string | undefined = undefined;
if (listItemId) {
  try {
    const iur = await sp.web.lists.getById(listId).items.getById(listItemId).update(objects, this.state.etag);
    newETag = iur.data['odata.etag'];
    if (onSubmitted) {
      onSubmitted(iur.data, this.props.returnListItemInstanceOnSubmit !== false ? iur.item : undefined);
    }
  }
  catch (error) {
    if (onSubmitError) {
      onSubmitError(objects, error);
    }
    console.log("Error", error);
  }
```

By validating the null check as below, the issue is resolved. 

```
else if (fieldType === "User") {
    objects[`${columnInternalName}Id`] = val.newValue.length === 0 ? null : val.newValue;
}
```

I have also corrected a spelling mistake at ```onSubmitClick``` 

from, **'val.newValue.lenght'**

```
          else if (fieldType === "UserMulti") {
            objects[`${columnInternalName}Id`] = { results: val.newValue.lenght === 0 ? null: val.newValue };
          }
```

To, **'val.newValue.length'** as below.

```
else if (fieldType === "UserMulti") {
            objects[`${columnInternalName}Id`] = {
              results: val.newValue.length === 0 ? null : val.newValue,
            };
          }
```

Thanks,
Nishkalank Bezawada
