### PR TITLE
Add null check for adaptive card elements

### DIFF
--- a/src/controls/adaptiveCardHost/fluentUI/Elements.tsx
+++ b/src/controls/adaptiveCardHost/fluentUI/Elements.tsx
@@ -637,7 +637,7 @@ export class FluentUITextInput extends Input {
 
   public get value(): string | undefined {
     if (this.renderedInputControlElement) {
-      return this.refControl.value;
+      return this.refControl?.value;
     }
     else {
       return undefined;
@@ -742,7 +742,7 @@ export class FluentUITimeInput extends Input {
 
   public get value(): string | undefined {
     if (this.renderedInputControlElement) {
-      return this.refControl.value;
+      return this.refControl?.value;
     }
     else {
       return undefined;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | 

#### What's in this Pull Request?
Added null checks to the rendering of adaptive card elements so that ```AdaptiveCardHost``` renders correctly in the Controls Test Webpart.
