### PR TITLE
Fixing Issue 1571 & Partial fix for 1174

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -207,6 +207,12 @@ export class DynamicForm extends React.Component<
             val.fieldDefaultValue = null;
             shouldBeReturnBack = true;
           }
+        } else if(val.fieldType === "Number"){
+          if(!val.showAsPercentage){
+            if((val.newValue < val.minimumValue) || (val.newValue > val.maximumValue)){
+              shouldBeReturnBack = true;
+            }
+          }
         }
       });
       if (shouldBeReturnBack) {
@@ -709,6 +715,9 @@ export class DynamicForm extends React.Component<
             listItemId: listItemId,
             principalType: principalType,
             description: field.Description,
+            maximumValue:field.MaximumValue,
+            minimumValue:field.MinimumValue,
+            showAsPercentage:field.ShowAsPercentage
           });
           tempFields.sort((a, b) => a.Order - b.Order);
         }

--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -95,6 +95,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
 
     const labelEl = <label className={(required) ? styles.fieldRequired + ' ' + styles.fieldLabel : styles.fieldLabel}>{labelText}</label>;
     const errorText = this.getRequiredErrorText();
+    const errorTextforNumber = this.getnumberErrorText();
     const errorTextEl = <text className={styles.errormessage}>{errorText}</text>;
     const descriptionEl = <text className={styles.fieldDescription}>{description}</text>;
     const hasImage = !!changedValue;
@@ -271,7 +272,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
             onChange={(e, newText) => { this.onChange(newText); }}
             disabled={disabled}
             onBlur={this.onBlur}
-            errorMessage={errorText} />
+            errorMessage={errorTextforNumber} />
           {descriptionEl}
         </div>;
 
@@ -588,6 +589,27 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       changedValue
     } = this.state;
     return (changedValue === undefined || changedValue === ''|| changedValue === null || this.isEmptyArray(changedValue)) && this.props.required ? strings.DynamicFormRequiredErrorMessage : null;
+  }
+
+  private getnumberErrorText = (): string => {
+    const {
+      changedValue
+    } = this.state;
+    const{
+      maximumValue,
+      minimumValue,
+      showAsPercentage
+    } = this.props;
+
+    if((changedValue === undefined || changedValue === ''|| changedValue === null || this.isEmptyArray(changedValue)) && this.props.required){
+      return strings.DynamicFormRequiredErrorMessage;
+    } else if((changedValue < minimumValue) || (changedValue > maximumValue)){
+      if(!showAsPercentage){
+        return strings.DynamicFormNumberErrorMessage
+                .replace('{0}', minimumValue.toString())
+                .replace('{1}', maximumValue.toString());
+      }
+    }
   }
 
   private isEmptyArray(value): boolean {

--- a/src/controls/dynamicForm/dynamicField/IDynamicFieldProps.ts
+++ b/src/controls/dynamicForm/dynamicField/IDynamicFieldProps.ts
@@ -34,4 +34,7 @@ export interface IDynamicFieldProps {
   additionalData?: FieldChangeAdditionalData;
   principalType?:string;
   description?: string;
+  maximumValue?: number;
+  minimumValue?: number;
+  showAsPercentage?: boolean;
 }

--- a/src/loc/bg-bg.ts
+++ b/src/loc/bg-bg.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Алтернативен текст",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Използвайте това местоположение:",
   "ListItemCommentDIalogDeleteSubText": "Наистина ли искате да изтриете този коментар?",
   "ListItemCommentsDialogDeleteTitle": "Потвърдете Изтриване на коментар",

--- a/src/loc/ca-es.ts
+++ b/src/loc/ca-es.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Text alternatiu",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Utilitzeu aquesta ubicació:",
   "ListItemCommentDIalogDeleteSubText": "Esteu segur que voleu suprimir aquest comentari?",
   "ListItemCommentsDialogDeleteTitle": "Confirmació de la supressió del comentari",

--- a/src/loc/da-dk.ts
+++ b/src/loc/da-dk.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternativ tekst",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Brug denne placering:",
   "ListItemCommentDIalogDeleteSubText": "Er du sikker på, at du vil slette denne kommentar?",
   "ListItemCommentsDialogDeleteTitle": "Bekræft kommentar til sletning",

--- a/src/loc/da-dk.ts
+++ b/src/loc/da-dk.ts
@@ -366,7 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternativ tekst",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
-  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
+  "DynamicFormNumberErrorMessage": "Værdien af ​​dette felt skal være mellem {0} og {1}.",
   "customDisplayName": "Brug denne placering:",
   "ListItemCommentDIalogDeleteSubText": "Er du sikker på, at du vil slette denne kommentar?",
   "ListItemCommentsDialogDeleteTitle": "Bekræft kommentar til sletning",

--- a/src/loc/de-de.ts
+++ b/src/loc/de-de.ts
@@ -366,7 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternativtext",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
-  "DynamicFormNumberErrorMessage": "Værdien af ​​dette felt skal være mellem {0} og {1}.",
+  "DynamicFormNumberErrorMessage": "Der Wert dieses Feldes muss zwischen {0} und {1} liegen.",
   "customDisplayName": "Verwenden Sie diesen Speicherort:",
   "ListItemCommentDIalogDeleteSubText": "Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?",
   "ListItemCommentsDialogDeleteTitle": "Kommentar löschen bestätigen",

--- a/src/loc/de-de.ts
+++ b/src/loc/de-de.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternativtext",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "Værdien af ​​dette felt skal være mellem {0} og {1}.",
   "customDisplayName": "Verwenden Sie diesen Speicherort:",
   "ListItemCommentDIalogDeleteSubText": "Sind Sie sicher, dass Sie diesen Kommentar löschen möchten?",
   "ListItemCommentsDialogDeleteTitle": "Kommentar löschen bestätigen",

--- a/src/loc/el-gr.ts
+++ b/src/loc/el-gr.ts
@@ -366,7 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Εναλλακτικό κείμενο",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
-  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
+  "DynamicFormNumberErrorMessage": "Η τιμή αυτού του πεδίου πρέπει να είναι μεταξύ {0} και {1}.",
   "customDisplayName": "Χρησιμοποιήστε αυτήν τη θέση:",
   "ListItemCommentDIalogDeleteSubText": "Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτό το σχόλιο;",
   "ListItemCommentsDialogDeleteTitle": "Επιβεβαίωση διαγραφής σχολίου",

--- a/src/loc/el-gr.ts
+++ b/src/loc/el-gr.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Εναλλακτικό κείμενο",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Χρησιμοποιήστε αυτήν τη θέση:",
   "ListItemCommentDIalogDeleteSubText": "Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτό το σχόλιο;",
   "ListItemCommentsDialogDeleteTitle": "Επιβεβαίωση διαγραφής σχολίου",

--- a/src/loc/en-us.ts
+++ b/src/loc/en-us.ts
@@ -384,6 +384,7 @@ define([], () => {
     DynamicFormEnterDescriptionPlaceholder: "Alternative text",
     DynamicFormDialogValidationErrorTitle: "Validation Error",
     DynamicFormDialogValidationErrorMessage: "There are validation errors, please fix them before saving.",
+    DynamicFormNumberErrorMessage: "The value of this field must be between {0} and {1}.",
     customDisplayName: "Use this location:",
     ListItemCommentDIalogDeleteSubText: "Are you sure that you want to delete this comment?",
     ListItemCommentsDialogDeleteTitle: "Confirm Delete Comment",

--- a/src/loc/es-es.ts
+++ b/src/loc/es-es.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Texto alternativo",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Utilice esta ubicación:",
   "ListItemCommentDIalogDeleteSubText": "¿Está seguro de que desea eliminar este comentario?",
   "ListItemCommentsDialogDeleteTitle": "Confirmar comentario de eliminación",

--- a/src/loc/et-ee.ts
+++ b/src/loc/et-ee.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Asetekst",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Kasuta seda asukohta:",
   "ListItemCommentDIalogDeleteSubText": "Kas soovite kindlasti selle kommentaari kustutada?",
   "ListItemCommentsDialogDeleteTitle": "Kommentaari kustutamise kinnitamine",

--- a/src/loc/eu-es.ts
+++ b/src/loc/eu-es.ts
@@ -382,5 +382,6 @@ TermSetNavigationNoTerms: "No terms defined",
   "DynamicFormEnterDescriptionPlaceholder": "Alternative text",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   };
 });

--- a/src/loc/fi-fi.ts
+++ b/src/loc/fi-fi.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Vaihtoehtoinen teksti",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "Tämän kentän arvon on oltava välillä {0} - {1}.",
   "customDisplayName": "Käytä tätä sijaintia:",
   "ListItemCommentDIalogDeleteSubText": "Haluatko varmasti poistaa tämän kommentin?",
   "ListItemCommentsDialogDeleteTitle": "Vahvista poista kommentti",

--- a/src/loc/fr-ca.ts
+++ b/src/loc/fr-ca.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Texte alternatif",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Utilisez cet emplacement :",
   "ListItemCommentDIalogDeleteSubText": "Êtes-vous sûr de vouloir supprimer ce commentaire?",
   "ListItemCommentsDialogDeleteTitle": "Confirmer supprimer le commentaire",

--- a/src/loc/fr-fr.ts
+++ b/src/loc/fr-fr.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Texte alternatif",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Utilisez cet emplacement :",
   "ListItemCommentDIalogDeleteSubText": "Êtes-vous sûr de vouloir supprimer ce commentaire ?",
   "ListItemCommentsDialogDeleteTitle": "Confirmer la suppression du commentaire",

--- a/src/loc/it-it.ts
+++ b/src/loc/it-it.ts
@@ -364,6 +364,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Testo alternativo",
   "DynamicFormDialogValidationErrorTitle": "Errori di validazione",
   "DynamicFormDialogValidationErrorMessage": "Sono presenti degli errori di validazione, si prega di correggerli prima di salvare le modifiche.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Utilizzare questa posizione:",
   "ListItemCommentDIalogDeleteSubText": "Eliminare questo commento?",
   "ListItemCommentsDialogDeleteTitle": "Conferma eliminazione commento",

--- a/src/loc/ja-jp.ts
+++ b/src/loc/ja-jp.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "代替テキスト",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "この場所を使用します。",
   "ListItemCommentDIalogDeleteSubText": "このコメントを削除しますか?",
   "ListItemCommentsDialogDeleteTitle": "コメントの削除の確認",

--- a/src/loc/lt-lt.ts
+++ b/src/loc/lt-lt.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternatyvus tekstas",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Naudokite šią vietą:",
   "ListItemCommentDIalogDeleteSubText": "Ar tikrai norite panaikinti šį komentarą?",
   "ListItemCommentsDialogDeleteTitle": "Patvirtinti naikinimo komentarą",

--- a/src/loc/lv-lv.ts
+++ b/src/loc/lv-lv.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternatīvais teksts",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Izmantojiet šo atrašanās vietu:",
   "ListItemCommentDIalogDeleteSubText": "Vai tiešām vēlaties dzēst šo komentāru?",
   "ListItemCommentsDialogDeleteTitle": "Apstiprināt dzēst komentāru",

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -368,6 +368,7 @@ declare interface IControlStrings {
   DynamicFormEnterDescriptionPlaceholder: string;
   DynamicFormDialogValidationErrorTitle: string;
   DynamicFormDialogValidationErrorMessage: string;
+  DynamicFormNumberErrorMessage: string;
 
   // Location picker
   customDisplayName: string;

--- a/src/loc/nb-no.ts
+++ b/src/loc/nb-no.ts
@@ -366,6 +366,7 @@ define([], () => {
     "DynamicFormEnterDescriptionPlaceholder": "Alternativ tekst",
     "DynamicFormDialogValidationErrorTitle": "Validation Error",
     "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+    "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
     "customDisplayName": "Bruk denne plasseringen:",
     "ListItemCommentDIalogDeleteSubText": "Er du sikker på at du vil slette denne kommentaren?",
     "ListItemCommentsDialogDeleteTitle": "Bekreft sletting av kommentar",

--- a/src/loc/nl-nl.ts
+++ b/src/loc/nl-nl.ts
@@ -364,6 +364,7 @@ define([], () => {
     "DynamicFormEnterDescriptionPlaceholder": "Alternatieve tekst",
     "DynamicFormDialogValidationErrorTitle": "Validation Error",
     "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+    "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
     "customDisplayName": "Gebruik deze locatie:",
     "ListItemCommentDIalogDeleteSubText": "Weet u zeker dat u deze opmerking wilt verwijderen?",
     "ListItemCommentsDialogDeleteTitle": "Opmerking verwijderen bevestigen",

--- a/src/loc/pl-pl.ts
+++ b/src/loc/pl-pl.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Tekst alternatywny",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Użyj tej lokalizacji:",
   "ListItemCommentDIalogDeleteSubText": "Czy na pewno chcesz usunąć ten komentarz?",
   "ListItemCommentsDialogDeleteTitle": "Potwierdź Usuń komentarz",

--- a/src/loc/pt-br.ts
+++ b/src/loc/pt-br.ts
@@ -364,6 +364,7 @@ define([], () => {
     DynamicFormEnterDescriptionPlaceholder: "Texto alternativo",
     DynamicFormDialogValidationErrorTitle: "Validation Error",
     DynamicFormDialogValidationErrorMessage: "There are validation errors, please fix them before saving.",
+    DynamicFormNumberErrorMessage: "The value of this field must be between {0} and {1}.",
     customDisplayName: "Utilize este local:",
     ListItemCommentDIalogDeleteSubText: "Tem a certeza que quer eliminar este comentário?",
     ListItemCommentsDialogDeleteTitle: "Confirmar Eliminar Comentário",

--- a/src/loc/pt-pt.ts
+++ b/src/loc/pt-pt.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Texto alternativo",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Utilize este local:",
   "ListItemCommentDIalogDeleteSubText": "Tem a certeza que quer eliminar este comentário?",
   "ListItemCommentsDialogDeleteTitle": "Confirmar Eliminar Comentário",

--- a/src/loc/ro-ro.ts
+++ b/src/loc/ro-ro.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Text alternativ",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Utilizați această locație:",
   "ListItemCommentDIalogDeleteSubText": "Sunteți sigur că doriți să ștergeți acest comentariu?",
   "ListItemCommentsDialogDeleteTitle": "Confirmați ștergerea comentariului",

--- a/src/loc/ru-ru.ts
+++ b/src/loc/ru-ru.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Альтернативный текст",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Используйте это расположение:",
   "ListItemCommentDIalogDeleteSubText": "Вы уверены, что хотите удалить этот комментарий?",
   "ListItemCommentsDialogDeleteTitle": "Подтвердить удаление комментария",

--- a/src/loc/sk-sk.ts
+++ b/src/loc/sk-sk.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternatívny text",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Použite toto umiestnenie:",
   "ListItemCommentDIalogDeleteSubText": "Naozaj chcete odstrániť tento komentár?",
   "ListItemCommentsDialogDeleteTitle": "Potvrdiť odstránenie komentára",

--- a/src/loc/sr-latn-rs.ts
+++ b/src/loc/sr-latn-rs.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternativni tekst",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Koristi ovu lokaciju:",
   "ListItemCommentDIalogDeleteSubText": "Želite li zaista da izbrišete ovaj komentar?",
   "ListItemCommentsDialogDeleteTitle": "Potvrda brisanja komentara",

--- a/src/loc/sv-se.ts
+++ b/src/loc/sv-se.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternativ text",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "Värdet på det här fältet måste vara mellan {0} och {1}.",
   "customDisplayName": "Använd den här platsen:",
   "ListItemCommentDIalogDeleteSubText": "Vill du ta bort den här kommentaren?",
   "ListItemCommentsDialogDeleteTitle": "Bekräfta ta bort kommentar",

--- a/src/loc/tr-tr.ts
+++ b/src/loc/tr-tr.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Alternatif metin",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Bu konumu kullan:",
   "ListItemCommentDIalogDeleteSubText": "Bu yorumu silmek istediğinizden emin misiniz?",
   "ListItemCommentsDialogDeleteTitle": "Açıklamayı Sil'i Onayla",

--- a/src/loc/vi-vn.ts
+++ b/src/loc/vi-vn.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "Văn bản thay thế",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "Sử dụng vị trí này:",
   "ListItemCommentDIalogDeleteSubText": "Bạn có chắc chắn rằng bạn muốn xóa bình luận này không?",
   "ListItemCommentsDialogDeleteTitle": "Xác nhận Xóa Chú thích",

--- a/src/loc/zh-cn.ts
+++ b/src/loc/zh-cn.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "备选文本",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "使用此位置：",
   "ListItemCommentDIalogDeleteSubText": "您确定要删除此评论吗？",
   "ListItemCommentsDialogDeleteTitle": "确认删除注释",

--- a/src/loc/zh-tw.ts
+++ b/src/loc/zh-tw.ts
@@ -366,6 +366,7 @@ define([], () => {
   "DynamicFormEnterDescriptionPlaceholder": "備選文字",
   "DynamicFormDialogValidationErrorTitle": "Validation Error",
   "DynamicFormDialogValidationErrorMessage": "There are validation errors, please fix them before saving.",
+  "DynamicFormNumberErrorMessage": "The value of this field must be between {0} and {1}.",
   "customDisplayName": "使用此位置：",
   "ListItemCommentDIalogDeleteSubText": "您確定要刪除此評論嗎？",
   "ListItemCommentsDialogDeleteTitle": "確認刪除註釋",

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -928,16 +928,14 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
     return (
       <div className={styles.controlsTest}>
-
-
         <div className="ms-font-m">
           {/* Change the list Id and list item id before you start to test this control */}
-          <DynamicForm 
-            context={this.props.context} 
-            listId={"1c2e8fb9-e604-4f30-8055-10b465b42921"} 
-            listItemId={7}
-            onCancelled={() => { console.log('Cancelled'); }} 
-            onSubmitted={async (listItem) => { /*let itemdata = await listItem.get();*/ console.log(listItem); }}></DynamicForm>
+          <DynamicForm context={this.props.context} listId={"8d26295d-c532-47c6-a2c5-d6e79c2ef523"} onCancelled={() => { console.log('Cancelled'); }} onSubmitted={async (listItem) => { let itemdata = await listItem.get(); console.log(itemdata["ID"]); }}></DynamicForm>
+        </div>
+        <div className="ms-font-m">
+          {/* Change the list Id and list item id before you start to test this control */}
+          {/* This DynamicForm display a dialog message when validation fails */}
+          <DynamicForm context={this.props.context} listId={"8d26295d-c532-47c6-a2c5-d6e79c2ef523"} onCancelled={() => { console.log('Cancelled'); }} onSubmitted={async (listItem) => { let itemdata = await listItem.get(); console.log(itemdata["ID"]); }} validationErrorDialogProps={{showDialogOnValidationError: true}}></DynamicForm>
         </div>
         <WebPartTitle displayMode={this.props.displayMode}
           title={this.props.title}

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -928,14 +928,16 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
     return (
       <div className={styles.controlsTest}>
+
+
         <div className="ms-font-m">
           {/* Change the list Id and list item id before you start to test this control */}
-          <DynamicForm context={this.props.context} listId={"8d26295d-c532-47c6-a2c5-d6e79c2ef523"} onCancelled={() => { console.log('Cancelled'); }} onSubmitted={async (listItem) => { let itemdata = await listItem.get(); console.log(itemdata["ID"]); }}></DynamicForm>
-        </div>
-        <div className="ms-font-m">
-          {/* Change the list Id and list item id before you start to test this control */}
-          {/* This DynamicForm display a dialog message when validation fails */}
-          <DynamicForm context={this.props.context} listId={"8d26295d-c532-47c6-a2c5-d6e79c2ef523"} onCancelled={() => { console.log('Cancelled'); }} onSubmitted={async (listItem) => { let itemdata = await listItem.get(); console.log(itemdata["ID"]); }} validationErrorDialogProps={{showDialogOnValidationError: true}}></DynamicForm>
+          <DynamicForm 
+            context={this.props.context} 
+            listId={"1c2e8fb9-e604-4f30-8055-10b465b42921"} 
+            listItemId={7}
+            onCancelled={() => { console.log('Cancelled'); }} 
+            onSubmitted={async (listItem) => { /*let itemdata = await listItem.get();*/ console.log(listItem); }}></DynamicForm>
         </div>
         <WebPartTitle displayMode={this.props.displayMode}
           title={this.props.title}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1571, partially #1174, mentioned in #Z

#### What's in this Pull Request?
#### Problem statement
When a column in list of type number, is configured with minimum and maximum value, the validation works fine on the list form but not in the Dynamic form. On dynamic form, user can enter any value and submit as mentioned in the [issue 1571](https://github.com/pnp/sp-dev-fx-controls-react/issues/1571) 

#### Solution
Fixing the ability to validate the number field when minimum and maximum value is defined in the list. 

I have added three field properties ```minimumValue```, ```maximumValue```, ```showAsPercentage```

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/16f32423-a672-4645-8369-82684a47e974)

(These properties are only available for ```Number``` field)

These properties are added to the ```fieldCollection``` and validates in the dynamic form according to the changedValue/newValue accordingly.


Thanks,
Nishkalank Bezawada
