### PR TITLE
Fix ModernTaxonomyPicker used language by checking for supported term…

### DIFF
--- a/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
+++ b/src/controls/modernTaxonomyPicker/ModernTaxonomyPicker.tsx
@@ -80,9 +80,9 @@ export function ModernTaxonomyPicker(props: IModernTaxonomyPickerProps): JSX.Ele
     taxonomyService.getTermStoreInfo()
       .then((termStoreInfo) => {
         setCurrentTermStoreInfo(termStoreInfo);
-        const languageTag = props.context.pageContext.cultureInfo.currentUICultureName !== '' ?
+        const languageTag = props.context.pageContext.cultureInfo.currentUICultureName !== '' && termStoreInfo.languageTags.includes(props.context.pageContext.cultureInfo.currentUICultureName) ?
           props.context.pageContext.cultureInfo.currentUICultureName :
-          currentTermStoreInfo.defaultLanguageTag;
+          termStoreInfo.defaultLanguageTag;
         setCurrentLanguageTag(languageTag);
         setSelectedOptions(Array.isArray(props.initialValues) ?
           props.initialValues.map(term => { return { ...term, languageTag: languageTag, termStoreInfo: termStoreInfo } as ITermInfo; }) :


### PR DESCRIPTION
… store languages

| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1573

#### What's in this Pull Request?

Changing how the language used by the ModernTaxonomyPicker is set by checking the currentUICultureName against the termStoreInfo.languageTags array and use currentTermStoreInfo.defaultLanguageTag if the current UI language is not supported (= not inside the termStoreInfo.languageTags array) by the term store.
I also noticed that the `currentTermStoreInfo` state was used directly after being set (it would be undefined because state update is asynchronous) which must have caused another bug if the currentUICultureName wasn't available. So I used the fetched `termStoreInfo` instead of the state. 

Thanks!