### PR TITLE
Fixing Issue 1580 - Broken behavior: files containing dots in the name

### DIFF
--- a/src/controls/listItemAttachments/utilities.ts
+++ b/src/controls/listItemAttachments/utilities.ts
@@ -34,8 +34,7 @@ export default class utilities {
    */
   public GetFileImageUrl(_file: IListItemAttachmentFile): Promise<string> {
     let _fileImageUrl: string = DOCICONURL_GENERIC;
-    const _fileTypes = _file.FileName.split('.');
-    const _fileExtension = _fileTypes[1];
+    const _fileExtension = _file.FileName.substr(_file.FileName.lastIndexOf('.') + 1);
 
    if ( !_fileExtension){
      return Promise.resolve(_fileImageUrl);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1580 

#### What's in this Pull Request?

Fixing the issue when adding attachments to the **ListAttachments** control that contain one or more dots (".") in the name, the file type icon is not displayed (ex. PDF, Word, etc.)


#### Solution
To load the attachment preview in method ```loadAttachmentPreview``` we call ```GetFileImageUrl``` to fetch the ```previewImageUrl```. 

#### The old code is as below, 

```
    const _fileTypes = _file.FileName.split('.');
    const _fileExtension = _fileTypes[1];
```

And since, the scenario when we have one or more dots (".") in the file name, the ```_fileExtension ``` which will get the first element of array from ```_fileTypes```

#### The corrected code is as below

```
const _fileExtension = _file.FileName.substr(_file.FileName.lastIndexOf('.') + 1);
```

this change will get the exact extension of the file. 

#### below are the images from my local workbench. 
![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/f59ac6ab-8e89-4988-b4c2-f7dc6ab1bba9)

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/91c589a9-01a5-474b-b82f-b6a51a24e722)

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/c9d8c8ae-fd37-4849-a02e-a00082bc5eef)


Thanks,
Nishkalank Bezawada

