### PR TITLE
Fix 1586 - controls are shown with error messages even if the values are assigned

### DIFF
--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -32,7 +32,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       spfxContext: { pageContext: this.props.context.pageContext }
     });
     this.state = {
-      changedValue: props.fieldType === 'Thumbnail' ? props.fieldDefaultValue : null
+      changedValue: props.fieldDefaultValue !== undefined || props.fieldDefaultValue !== '' || props.fieldDefaultValue !== null || !this.isEmptyArray(props.fieldDefaultValue) ? props.fieldDefaultValue : null
     };
   }
 


### PR DESCRIPTION
…alues are assigned

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1586 

#### What's in this Pull Request?

Fixing issue #1586, Dynamic form controls are loaded with required field error message even if the values are assigned. 

#### Problem
On load of the form, the error message 'You can't leave this blank' is shown for all the columns which are set as 'Required'. This is happening when we editing/opening existing list item

#### Solution
In ```DynamicField``` component, the ```errorText``` is set at ```getRequiredErrorText``` method based on the property ```changedValue``` as below, 

```
  private getRequiredErrorText = (): string => {
    const {
      changedValue
    } = this.state;
    return (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) && this.props.required ? strings.DynamicFormRequiredErrorMessage : null;
  }
```
This ```changedValue``` state is set in the constructor as below, 

```
    this.state = {
      changedValue: props.fieldType === 'Thumbnail' ? props.fieldDefaultValue : null
    };
```
Resulting in having the changedValue always set to null as per above condition.

So, by setting the state as below, the issue will be resolved. 

```  
constructor(props: IDynamicFieldProps) {
    super(props);
    sp.setup({
      spfxContext: { pageContext: this.props.context.pageContext }
    });
    this.state = {
      changedValue: props.fieldDefaultValue !== undefined || props.fieldDefaultValue !== '' || props.fieldDefaultValue !== null || !this.isEmptyArray(props.fieldDefaultValue) ? props.fieldDefaultValue : null
    };
  }
```
