### PR TITLE
Fast-serve updated to the latest version and serve warnings fixed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "react-test-renderer": "17.0.1",
         "request-promise": "4.2.5",
         "sonarqube-scanner": "2.8.2",
-        "spfx-fast-serve-helpers": "1.17.0",
+        "spfx-fast-serve-helpers": "1.17.3",
         "ts-jest": "^25.5.1",
         "tslib": "2.3.1",
         "tslint-microsoft-contrib": "6.2.0",
@@ -27215,12 +27215,6 @@
       "deprecated": "use String.prototype.padStart()",
       "dev": true
     },
-    "node_modules/levdist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/levdist/-/levdist-1.0.0.tgz",
-      "integrity": "sha512-YguwC2spb0pqpJM3a5OsBhih/GG2ZHoaSHnmBqhEI7997a36buhqcRTegEjozHxyxByIwLpZHZTVYMThq+Zd3g==",
-      "dev": true
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -27290,15 +27284,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/line-diff": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/line-diff/-/line-diff-2.1.1.tgz",
-      "integrity": "sha512-vswdynAI5AMPJacOo2o+JJ4caDJbnY2NEqms4MhMW0NJbjh3skP/brpVTAgBxrg55NRZ2Vtw88ef18hnagIpYQ==",
-      "dev": true,
-      "dependencies": {
-        "levdist": "^1.0.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -34908,23 +34893,19 @@
       }
     },
     "node_modules/spfx-css-modules-typescript-loader": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/spfx-css-modules-typescript-loader/-/spfx-css-modules-typescript-loader-4.0.5.tgz",
-      "integrity": "sha512-zjoqyN8Va0+pFQc8EUXF/TcV4Bh/7gWkiTcx/wSv3nXS5BrxcLMaze4KxKJA+xdls9p6jaWPlEzkFSPetzaOZg==",
-      "dev": true,
-      "dependencies": {
-        "line-diff": "^2.0.1",
-        "loader-utils": "^1.2.3"
-      }
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/spfx-css-modules-typescript-loader/-/spfx-css-modules-typescript-loader-4.0.6.tgz",
+      "integrity": "sha512-N/wzebd4ZepUdIMDkJZgd9v4rXTtI9wQ4qfaFjnCapLoifnVdlUal+IosSW/t7LdB4vlRcBkaLsawLciKG8K8w==",
+      "dev": true
     },
     "node_modules/spfx-fast-serve-helpers": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/spfx-fast-serve-helpers/-/spfx-fast-serve-helpers-1.17.0.tgz",
-      "integrity": "sha512-Hv5lcszGtINWZ/22TUYn8Aox3JcShHv7SChhTHIf73U9n505vNILQXOWDXZz0oBDBbSW5gfIba5OJnFz6BMYFg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/spfx-fast-serve-helpers/-/spfx-fast-serve-helpers-1.17.3.tgz",
+      "integrity": "sha512-5/U4Vmm1HWjfaDH+tPUyKJjruKFcI4hksrGgFGX2fx1fQSNaU3e6Ec3N16T7bpViUSXxWF4zZ9eVkPxjGjMH6w==",
       "dev": true,
       "dependencies": {
         "@microsoft/loader-load-themed-styles": "2.0.27",
-        "@microsoft/spfx-heft-plugins": "1.17.0",
+        "@microsoft/spfx-heft-plugins": "1.17.4",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.7",
         "@types/copy-webpack-plugin": "6.4.3",
         "@types/loader-utils": "2.0.2",
@@ -34950,7 +34931,7 @@
         "react-refresh-typescript": "2.0.6",
         "sass": "1.44.0",
         "sass-loader": "9.0.3",
-        "spfx-css-modules-typescript-loader": "4.0.5",
+        "spfx-css-modules-typescript-loader": "4.0.6",
         "style-loader": "1.1.3",
         "ts-loader": "8.1.0",
         "tsconfig": "7.0.0",
@@ -35028,9 +35009,9 @@
       "dev": true
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/@microsoft/sp-css-loader": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-css-loader/-/sp-css-loader-1.17.0.tgz",
-      "integrity": "sha512-he/3+5wKsD45XW9hd/2QnPE2DH5ZMzT1OhGsY1uGye4NLo9b8FMI6yX9EH6hmgiwSHr4gQiJlYxK1RleRqrKOg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-css-loader/-/sp-css-loader-1.17.4.tgz",
+      "integrity": "sha512-HBzv+/cu1Mxc5j0LA04EhoXndaNhCGk4Xhqy1KZioNSZgz5DbrsEWtNklexy0wXoJP+dbro+mtZYb/B07EvV6Q==",
       "dev": true,
       "dependencies": {
         "@microsoft/load-themed-styles": "1.10.292",
@@ -35244,9 +35225,9 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/@microsoft/sp-css-loader/node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
+      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
       "dev": true,
       "funding": [
         {
@@ -35290,9 +35271,9 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/@microsoft/sp-module-interfaces": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.17.0.tgz",
-      "integrity": "sha512-aKb/xH+9Ze9ok9XFUXrRGeShytQJFMH9QR/afUscwTN+gQsPHuJbC4OZRmbsl1lKOA3bDbNmlzgDBqF03O1eSg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.17.4.tgz",
+      "integrity": "sha512-+tVV2O9B5i2RXdziEvg9FnKTBc2FgFn1XxbCfpmUj+F/Gh3PMtG0XyquBFY12jjxObEIv78J0A0fK2x0shZMLw==",
       "dev": true,
       "dependencies": {
         "@rushstack/node-core-library": "3.55.2",
@@ -35303,17 +35284,17 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/@microsoft/spfx-heft-plugins": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/spfx-heft-plugins/-/spfx-heft-plugins-1.17.0.tgz",
-      "integrity": "sha512-WqNcujeL9N/lc20/HnpdafTWTxUTzSEstErZ4R9QwaY6xfNcyi9/smOvpZygjEXuaj9JNofKOOeGhwWqruLGHg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/spfx-heft-plugins/-/spfx-heft-plugins-1.17.4.tgz",
+      "integrity": "sha512-BOTYm5H1coXpgp529PbI1XtrNGSI42c2EwxuR48ZThM20N8OagQeto5wpQh4z2wqdUhDpFVLu5gFqAEmG5v1Bg==",
       "dev": true,
       "dependencies": {
         "@azure/storage-blob": "~12.11.0",
         "@microsoft/load-themed-styles": "1.10.292",
         "@microsoft/loader-load-themed-styles": "2.0.27",
         "@microsoft/rush-lib": "5.93.1",
-        "@microsoft/sp-css-loader": "1.17.0",
-        "@microsoft/sp-module-interfaces": "1.17.0",
+        "@microsoft/sp-css-loader": "1.17.4",
+        "@microsoft/sp-module-interfaces": "1.17.4",
         "@rushstack/heft-config-file": "0.11.9",
         "@rushstack/localization-utilities": "0.8.46",
         "@rushstack/node-core-library": "3.55.2",
@@ -35638,9 +35619,9 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/@microsoft/spfx-heft-plugins/node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
+      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
       "dev": true,
       "funding": [
         {
@@ -35874,9 +35855,9 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/@microsoft/spfx-heft-plugins/node_modules/webpack-dev-server/node_modules/schema-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
-      "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -37628,9 +37609,9 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/postcss-loader/node_modules/schema-utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-      "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -65148,12 +65129,6 @@
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
       "dev": true
     },
-    "levdist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/levdist/-/levdist-1.0.0.tgz",
-      "integrity": "sha512-YguwC2spb0pqpJM3a5OsBhih/GG2ZHoaSHnmBqhEI7997a36buhqcRTegEjozHxyxByIwLpZHZTVYMThq+Zd3g==",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -65211,15 +65186,6 @@
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "dev": true
-    },
-    "line-diff": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/line-diff/-/line-diff-2.1.1.tgz",
-      "integrity": "sha512-vswdynAI5AMPJacOo2o+JJ4caDJbnY2NEqms4MhMW0NJbjh3skP/brpVTAgBxrg55NRZ2Vtw88ef18hnagIpYQ==",
-      "dev": true,
-      "requires": {
-        "levdist": "^1.0.0"
-      }
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -71221,23 +71187,19 @@
       }
     },
     "spfx-css-modules-typescript-loader": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/spfx-css-modules-typescript-loader/-/spfx-css-modules-typescript-loader-4.0.5.tgz",
-      "integrity": "sha512-zjoqyN8Va0+pFQc8EUXF/TcV4Bh/7gWkiTcx/wSv3nXS5BrxcLMaze4KxKJA+xdls9p6jaWPlEzkFSPetzaOZg==",
-      "dev": true,
-      "requires": {
-        "line-diff": "^2.0.1",
-        "loader-utils": "^1.2.3"
-      }
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/spfx-css-modules-typescript-loader/-/spfx-css-modules-typescript-loader-4.0.6.tgz",
+      "integrity": "sha512-N/wzebd4ZepUdIMDkJZgd9v4rXTtI9wQ4qfaFjnCapLoifnVdlUal+IosSW/t7LdB4vlRcBkaLsawLciKG8K8w==",
+      "dev": true
     },
     "spfx-fast-serve-helpers": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/spfx-fast-serve-helpers/-/spfx-fast-serve-helpers-1.17.0.tgz",
-      "integrity": "sha512-Hv5lcszGtINWZ/22TUYn8Aox3JcShHv7SChhTHIf73U9n505vNILQXOWDXZz0oBDBbSW5gfIba5OJnFz6BMYFg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/spfx-fast-serve-helpers/-/spfx-fast-serve-helpers-1.17.3.tgz",
+      "integrity": "sha512-5/U4Vmm1HWjfaDH+tPUyKJjruKFcI4hksrGgFGX2fx1fQSNaU3e6Ec3N16T7bpViUSXxWF4zZ9eVkPxjGjMH6w==",
       "dev": true,
       "requires": {
         "@microsoft/loader-load-themed-styles": "2.0.27",
-        "@microsoft/spfx-heft-plugins": "1.17.0",
+        "@microsoft/spfx-heft-plugins": "1.17.4",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.7",
         "@types/copy-webpack-plugin": "6.4.3",
         "@types/loader-utils": "2.0.2",
@@ -71263,7 +71225,7 @@
         "react-refresh-typescript": "2.0.6",
         "sass": "1.44.0",
         "sass-loader": "9.0.3",
-        "spfx-css-modules-typescript-loader": "4.0.5",
+        "spfx-css-modules-typescript-loader": "4.0.6",
         "style-loader": "1.1.3",
         "ts-loader": "8.1.0",
         "tsconfig": "7.0.0",
@@ -71331,9 +71293,9 @@
           "dev": true
         },
         "@microsoft/sp-css-loader": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-css-loader/-/sp-css-loader-1.17.0.tgz",
-          "integrity": "sha512-he/3+5wKsD45XW9hd/2QnPE2DH5ZMzT1OhGsY1uGye4NLo9b8FMI6yX9EH6hmgiwSHr4gQiJlYxK1RleRqrKOg==",
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-css-loader/-/sp-css-loader-1.17.4.tgz",
+          "integrity": "sha512-HBzv+/cu1Mxc5j0LA04EhoXndaNhCGk4Xhqy1KZioNSZgz5DbrsEWtNklexy0wXoJP+dbro+mtZYb/B07EvV6Q==",
           "dev": true,
           "requires": {
             "@microsoft/load-themed-styles": "1.10.292",
@@ -71497,9 +71459,9 @@
               }
             },
             "postcss": {
-              "version": "8.4.24",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-              "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+              "version": "8.4.26",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
+              "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
               "dev": true,
               "requires": {
                 "nanoid": "^3.3.6",
@@ -71527,9 +71489,9 @@
           }
         },
         "@microsoft/sp-module-interfaces": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.17.0.tgz",
-          "integrity": "sha512-aKb/xH+9Ze9ok9XFUXrRGeShytQJFMH9QR/afUscwTN+gQsPHuJbC4OZRmbsl1lKOA3bDbNmlzgDBqF03O1eSg==",
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.17.4.tgz",
+          "integrity": "sha512-+tVV2O9B5i2RXdziEvg9FnKTBc2FgFn1XxbCfpmUj+F/Gh3PMtG0XyquBFY12jjxObEIv78J0A0fK2x0shZMLw==",
           "dev": true,
           "requires": {
             "@rushstack/node-core-library": "3.55.2",
@@ -71537,17 +71499,17 @@
           }
         },
         "@microsoft/spfx-heft-plugins": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/spfx-heft-plugins/-/spfx-heft-plugins-1.17.0.tgz",
-          "integrity": "sha512-WqNcujeL9N/lc20/HnpdafTWTxUTzSEstErZ4R9QwaY6xfNcyi9/smOvpZygjEXuaj9JNofKOOeGhwWqruLGHg==",
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/@microsoft/spfx-heft-plugins/-/spfx-heft-plugins-1.17.4.tgz",
+          "integrity": "sha512-BOTYm5H1coXpgp529PbI1XtrNGSI42c2EwxuR48ZThM20N8OagQeto5wpQh4z2wqdUhDpFVLu5gFqAEmG5v1Bg==",
           "dev": true,
           "requires": {
             "@azure/storage-blob": "~12.11.0",
             "@microsoft/load-themed-styles": "1.10.292",
             "@microsoft/loader-load-themed-styles": "2.0.27",
             "@microsoft/rush-lib": "5.93.1",
-            "@microsoft/sp-css-loader": "1.17.0",
-            "@microsoft/sp-module-interfaces": "1.17.0",
+            "@microsoft/sp-css-loader": "1.17.4",
+            "@microsoft/sp-module-interfaces": "1.17.4",
             "@rushstack/heft-config-file": "0.11.9",
             "@rushstack/localization-utilities": "0.8.46",
             "@rushstack/node-core-library": "3.55.2",
@@ -71773,9 +71735,9 @@
               }
             },
             "postcss": {
-              "version": "8.4.24",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-              "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+              "version": "8.4.26",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
+              "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
               "dev": true,
               "requires": {
                 "nanoid": "^3.3.6",
@@ -71938,9 +71900,9 @@
               },
               "dependencies": {
                 "schema-utils": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
-                  "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+                  "version": "4.2.0",
+                  "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+                  "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
                   "dev": true,
                   "requires": {
                     "@types/json-schema": "^7.0.9",
@@ -73279,9 +73241,9 @@
           },
           "dependencies": {
             "schema-utils": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-              "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+              "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
               "dev": true,
               "requires": {
                 "@types/json-schema": "^7.0.8",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-test-renderer": "17.0.1",
     "request-promise": "4.2.5",
     "sonarqube-scanner": "2.8.2",
-    "spfx-fast-serve-helpers": "1.17.0",
+    "spfx-fast-serve-helpers": "1.17.3",
     "ts-jest": "^25.5.1",
     "tslib": "2.3.1",
     "tslint-microsoft-contrib": "6.2.0",

--- a/src/controls/carousel/index.ts
+++ b/src/controls/carousel/index.ts
@@ -1,4 +1,4 @@
 export * from "./ICarouselProps";
 export * from "./ICarouselState";
 export * from "./Carousel";
-export { ICarouselImageProps } from "./CarouselImage";
+export type { ICarouselImageProps } from "./CarouselImage";

--- a/src/controls/folderExplorer/FolderExplorer/index.ts
+++ b/src/controls/folderExplorer/FolderExplorer/index.ts
@@ -1,4 +1,4 @@
 export * from './FolderExplorer';
 export * from './IFolderExplorerProps';
 export * from './IFolderExplorerState';
-export { IBreadcrumbItem } from "office-ui-fabric-react/lib/Breadcrumb";
+export type { IBreadcrumbItem } from "office-ui-fabric-react/lib/Breadcrumb";

--- a/src/controls/folderExplorer/NewFolder/NewFolder.module.scss
+++ b/src/controls/folderExplorer/NewFolder/NewFolder.module.scss
@@ -8,7 +8,7 @@
   line-height: 32px;
   border-width: 1px;
   display: flex;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .libraryItem:hover {

--- a/src/controls/folderExplorer/index.ts
+++ b/src/controls/folderExplorer/index.ts
@@ -1,2 +1,2 @@
 export * from "./FolderExplorer/index";
-export {IFolder} from "../../services/IFolderExplorerService";
+export type { IFolder } from "../../services/IFolderExplorerService";

--- a/src/controls/toolbar/index.ts
+++ b/src/controls/toolbar/index.ts
@@ -1,3 +1,3 @@
 export * from "./Toolbar";
-export { TActionGroups, TFilters } from "./ToolbarActionsUtils";
+export type { TActionGroups, TFilters } from "./ToolbarActionsUtils";
 export * from '../../common/model/TAction';


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Enhancement   | ✅ 
| New feature?    | 
| New sample?      | 
| Related issues?  | 

#### What's in this Pull Request?

Fast-serve was updated to the latest version, which additionally improves rebuild speed 2-3x times. Also some webpack warnings were fixed for fast-serve (basically the export of interfaces with `type` keyword and also css value was missing `flex` attribute)

