### PR TITLE
#1597

### DIFF
--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -534,7 +534,7 @@ export default class SPTermStorePickerService {
     if (term.Paths && term.Paths.length > 0) {
       const fullPath = term.Paths[0].replace(/^\[/, "").replace(/\]$/, "");
       const fullPathParts = fullPath.split(":");
-      path = fullPathParts.join(";") + ";" + term.DefaultLabel;
+      path = fullPathParts.slice(1).join(";") + ";" + term.DefaultLabel;
       termSetName = fullPathParts[0];
     }
     return {


### PR DESCRIPTION
https://github.com/pnp/sp-dev-fx-controls-react/issues/1597

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1597, partially #Y, mentioned in #Z

#### What's in this Pull Request?

This PR is the hotfix for issue #1597 to avoid termset name in term path when user pick up term from suggestion.

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/29603048/60fabd1e-09e9-4d1a-8ad0-5814161f75aa)

And it won't have double termset name in the title of term suggestion
![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/29603048/10084676-98ae-4bba-9bbe-3a8babce80a9)




