### PR TITLE
Bugfix for issue 1568

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -580,8 +580,8 @@ export class DynamicForm extends React.Component<
             hiddenName = response.value;
             termSetId = field.TermSetId;
             anchorId = field.AnchorId;
-            if (item !== null) {
-              item[field.InternalName].forEach((element) => {
+            if (item !== null && item[field.InternalName] !== null && item[field.InternalName].results !== null) {
+              item[field.InternalName].results.forEach((element) => {
                 selectedTags.push({
                   key: element.TermGuid,
                   name: element.Label,


### PR DESCRIPTION
Dynamic Form accessed TaxonomyFieldTypeMulti without considering sub-array "results".

| Q               | A
| --------------- | ---
| Bug fix?        | [x ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1568 

#### What's in this Pull Request?

In Dynamic Form: TaxonomyFieldTypeMulti now uses "results" sub-array to a accress the item's data.