### PR TITLE
Fixing issue 1612 & 1603 - PeoplePicker won't accept Multiple Users with the same name

### DIFF
--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -280,7 +280,7 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
     if (!personas || !personas.length || personas.length === 0) {
       return false;
     }
-    return personas.filter(item => item.text === persona.text).length > 0;
+    return personas.some(item => item.text === persona.text && item.secondaryText === persona.secondaryText);
   }
 
 

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -1478,7 +1478,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
 
           <PeoplePicker context={this.props.context}
             titleText="People Picker (tenant scoped)"
-            personSelectionLimit={5}
+            personSelectionLimit={10}
             // groupName={"Team Site Owners"}
             showtooltip={true}
             required={true}
@@ -1487,7 +1487,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             onChange={this._getPeoplePickerItems}
             showHiddenInUI={false}
             principalTypes={[PrincipalType.User, PrincipalType.SharePointGroup, PrincipalType.SecurityGroup, PrincipalType.DistributionList]}
-            suggestionsLimit={2}
+            suggestionsLimit={5}
             resolveDelay={200}
             placeholder={'Select a SharePoint principal (User or Group)'}
             onGetErrorMessage={async (items: any[]) => {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1612 & #1603 

#### What's in this Pull Request?
Fixing Issue #1612  
Fixing Issue #1603 

### Problem Statement
People picker wont accept users with same First Name & Last Name but with different LoginName/Emails.

### Steps to reproduce

Added few Users in EntraID as below

| First Name | Last Name  | Email
| --------------- | ---------- | ------
| John | Smith | john.smith.01@pm3q.onmicrosoft.com
| John | Smith | john.smith.02@pm3q.onmicrosoft.com
| John | Smith |  john.smith.03@pm3q.onmicrosoft.com

With this, If we are selecting John Smith with email john.smith.01@pm3q.onmicrosoft.com at first, we are not able to add other Users with same names but with different emails as above. 

### Solution
In PeoplePickerComponent, ```onSearchFieldChanged``` after results are fetched, the results are sent to 'removeDuplicates' to the method, ```listContainsPersona``` 

This method was just filtering with the names as below, 

```
  private listContainsPersona = (persona: IPersonaProps, personas: IPersonaProps[]): boolean => {
    if (!personas || !personas.length || personas.length === 0) {
      return false;
    }
    return personas.filter(item => item.text === persona.text).length > 0;
  }
```
And with this reason, the next user is not getting accepted, as the below code returns true always
```return personas.filter(item => item.text === persona.text).length > 0;``` 

By making a change as below to also compare with ```secondaryText``` will get the users with same names and with different emails

```
  private listContainsPersona = (persona: IPersonaProps, personas: IPersonaProps[]): boolean => {
    if (!personas || !personas.length || personas.length === 0) {
      return false;
    }
    return personas.some(item => item.text === persona.text && item.secondaryText === persona.secondaryText);
  }
```

With this change, PeoplePicker will accept users with same First Name & Last Name but with different LoginName/Emails (Gif below)


![MultipleUsersWithSameNamebutDifferentLoginNames](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/9041ce50-0516-471a-99d5-49c08c856bed)


Thanks,
Nishkalank Bezawada

