### PR TITLE
Fix Issue 1392 - New items are always created with the default content type if the list has multiple content types

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -287,7 +287,8 @@ export class DynamicForm extends React.Component<
             } else {
               objects[columnInternalName] = null;
             }
-          } else {
+          }
+          else {
             objects[columnInternalName] = val.newValue;
           }
         }
@@ -332,10 +333,14 @@ export class DynamicForm extends React.Component<
       else if (
         contentTypeId === undefined ||
         contentTypeId === "" ||
-        !contentTypeId.startsWith("0x0120")
+        !contentTypeId.startsWith("0x0120")||
+        contentTypeId.startsWith("0x01")
       ) {
         // We are adding a new list item
         try {
+          const contentTypeIdField = "ContentTypeId";
+          //check if item contenttype is passed, then update the object with content type id, else, pass the object 
+          contentTypeId !== undefined && contentTypeId.startsWith("0x01") ? objects[contentTypeIdField] = contentTypeId : objects;
           const iar = await sp.web.lists.getById(listId).items.add(objects);
           if (onSubmitted) {
             onSubmitted(
@@ -351,7 +356,8 @@ export class DynamicForm extends React.Component<
           }
           console.log("Error", error);
         }
-      } else if (contentTypeId.startsWith("0x0120")) {
+      }
+      else if (contentTypeId.startsWith("0x0120")) {
         // We are adding a folder or a Document Set
         try {
           const idField = "ID";


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1392 

#### What's in this Pull Request?
Fix for issue #1392 
The site has a list called List1. List1 has multiple content types, CT1, CT2 and CT3, the default content type is CT1. All content types have different fields added to them. When the user opens the new form, and creates a new item, the new item's CT matches the one the user chooses on the sharepoint interface.

#### Expected behaviour
When ```contentTypeId``` is passed as property to Dynamic Form, New item should be created based on  ```contentTypeId``` which is passed. 

#### Solution
Èxtra check is done at method ```onSubmitClick``` while creating a new item, as below

```
const contentTypeIdField = "ContentTypeId";
contentTypeId !== undefined && contentTypeId.startsWith("0x01") ? objects[contentTypeIdField] = contentTypeId : objects;
```



#### New Item with CT scenario

![Issue 1392 New Item with CT (2)](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/d9c649ad-56df-4e03-9cf6-f8d37ae26473)

#### Edit item scenario

![Issue 1392 Edit Scenario1](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/4e2d4b63-3a3d-4b5f-812b-7eb677fa9af9)


#### New item without CT Scenario

![Issue 1392 New item without CT (1)](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/4be4e736-0faf-4789-849a-92118bd3d297)

Thanks,
Nishkalank