### PR TITLE
[ListItemAttachments] - Upload files in sequence not parallel

### DIFF
--- a/src/controls/listItemAttachments/ListItemAttachments.tsx
+++ b/src/controls/listItemAttachments/ListItemAttachments.tsx
@@ -76,12 +76,14 @@ export class ListItemAttachments extends React.Component<IListItemAttachmentsPro
 
   public async uploadAttachments(itemId: number): Promise<void> {
     if (this.state.filesToUpload) {
-      await Promise.all(this.state.filesToUpload.map(file => this._spservice.addAttachment(
-        this.props.listId,
-        itemId,
-        file.name,
-        file,
-        this.props.webUrl)));
+      for (const file of this.state.filesToUpload) {
+        await this._spservice.addAttachment(
+          this.props.listId,
+          itemId,
+          file.name,
+          file,
+          this.props.webUrl);
+      }
     }
     return new Promise<void>((resolve, reject) => {
       this.setState({


### PR DESCRIPTION
As pr. issue #1644 there's an issue when uploading multiple attachments at the same time to the same list item

| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes  #1644

#### What's in this Pull Request?

This PR changes the "order" in which attachments are uploaded, before they where uploaded in parallel, however, doing so sometimes causes SharePoint to throw an HTTP 409 when adding several attachments at the same time, this change makes it so the files are uploaded in one long sequence preventing the issue
