### PR TITLE
Issue #1651. Added placeholder for RichText urls.

### DIFF
--- a/src/controls/richText/RichText.tsx
+++ b/src/controls/richText/RichText.tsx
@@ -377,7 +377,8 @@ export class RichText extends React.Component<IRichTextProps, IRichTextState> {
           containerClassName: 'ms-dialogMainOverride'
         }}>
         <TextField label={strings.AddressFieldLabel}
-          value={this.state.insertUrl !== undefined ? this.state.insertUrl : "https://"}
+          placeholder="https://"
+          value={this.state.insertUrl !== undefined ? this.state.insertUrl : ""}
           onChange={(e, newValue?: string) => {
             this.setState({
               insertUrl: newValue


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1651

#### What's in this Pull Request?

This PR fixes the issue where the url dialog for RichText controls has https:// as its value instead of as a place holder text.