### PR TITLE
Fix click behavior in ListItemAttachments component

### DIFF
--- a/src/controls/listItemAttachments/ListItemAttachments.tsx
+++ b/src/controls/listItemAttachments/ListItemAttachments.tsx
@@ -267,6 +267,7 @@ export class ListItemAttachments extends React.Component<IListItemAttachmentsPro
             this.state.attachments.map(file => {
               const fileName = file.FileName;
               const previewImage = this.previewImages[fileName];
+              const clickDisabled = !this.state.itemId;
               return (
                 <div key={fileName} className={styles.documentCardWrapper}>
                   <TooltipHost
@@ -276,8 +277,8 @@ export class ListItemAttachments extends React.Component<IListItemAttachmentsPro
                     directionalHint={DirectionalHint.rightCenter}>
 
                     <DocumentCard
-                      onClickHref={!openAttachmentsInNewWindow && `${file.ServerRelativeUrl}?web=1`}
-                      onClick={openAttachmentsInNewWindow && (() => window.open(`${file.ServerRelativeUrl}?web=1`, "_blank"))} // JJ - 20200613 - needed to support Microsoft Teams
+                      onClickHref={!clickDisabled && !openAttachmentsInNewWindow && `${file.ServerRelativeUrl}?web=1`}
+                      onClick={!clickDisabled && openAttachmentsInNewWindow && (() => window.open(`${file.ServerRelativeUrl}?web=1`, "_blank"))} // JJ - 20200613 - needed to support Microsoft Teams
                       className={styles.documentCard}>
                       <DocumentCardPreview previewImages={[previewImage]} />
                       <Label className={styles.fileLabel}>{fileName}</Label>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1679

#### What's in this Pull Request?

This PR contains the fix for #1679

### Problem

Clicking the document card when no itemId is present results in an invalid url being opened.

### Solution

Only add onClick and onClickHref props when itemId is present.