### PR TITLE
ListView - Added ability to apply header styling

### DIFF
--- a/src/controls/listView/IListView.ts
+++ b/src/controls/listView/IListView.ts
@@ -80,6 +80,11 @@ export interface IListViewProps {
    */
   listClassName?: string;
   /**
+   * Class name to apply additional styles on list view header
+   * (min-height 17px)
+   */
+  headerClassName?: string;
+  /**
    * Custom sorting function.
    * @returns sorted collection of items
    */

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -572,17 +572,40 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
       return null;
     }
 
+    const headerProps = { 
+      ...props,
+      className: this.props.headerClassName,
+      styles: {
+        root: { 
+          lineHeight: "normal",
+          minHeight: '17px',
+          '.ms-DetailsHeader-cell': {
+            whiteSpace: 'normal',
+            lineHeight: 'normal',
+            height: '100%',
+          },
+          '.ms-DetailsHeader-cellTitle': {
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            flexWrap: 'nowrap',
+            justifyContent: 'flex-start',
+          },
+          ...props.styles,
+        },
+      },
+    }
+
     if (this.props.stickyHeader) {
       return (
         <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced>
-          {defaultRender({
-            ...props,
-          })}
+          {defaultRender(headerProps)}
         </Sticky>
       );
     }
 
-    return defaultRender(props);
+    return defaultRender(headerProps)
   }
   /**
    * Default React component render method

--- a/src/webparts/controlsTest/components/ControlsTest.module.scss
+++ b/src/webparts/controlsTest/components/ControlsTest.module.scss
@@ -98,6 +98,12 @@ $themePrimary: '[theme:themePrimary, default:#0078d7]';
   .listViewWrapper {
     height: 200px;
   }
+
+  .listViewHeader { 
+    padding-top: 1px;
+    padding-bottom: 1px;
+    height: 25px;
+  }
 }
 
 .dialogContainer {

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -1549,6 +1549,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             onDrop={this._getDropFiles}
             stickyHeader={true}
             className={styles.listViewWrapper}
+            headerClassName={styles.listViewHeader}
           // defaultFilter="Team"
           />
         </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | Partially adds #410

#### What's in this Pull Request?
(This is my 1st open source contribution and I'm still fresh at TS/JS... bear with me.)

I added the ability to apply custom styles to the header of a ListView via optional prop headerClassName. 

Something I was not able to implement was the ability to modify the font styling of the header text (size, weight, etc), so I set the header min-height to 17px which seemed small enough to scrunch everything without clipping any text - I tried testing as many scenarios as I could. Theoretically, to modify the font styling, I think you could add another styling prop to ListView, and apply that prop to '.ms-DetailsHeader-cellTitle' in ListView.tsx... I can experiment with this at another time.

For _my_ use case, although likely unconventional, I'm using a ListView in a tight spot on a page and need all the real estate being taken up by the default padding (padding-top of 16px) and line height (42px iirc). 

Let me know if I'm, at all, doing this incorrectly (lol).