### PR TITLE
Use stringMatchOption instead of deprecated stringMatchId #1688

### DIFF
--- a/src/services/SPTaxonomyService.ts
+++ b/src/services/SPTaxonomyService.ts
@@ -58,13 +58,13 @@ export class SPTaxonomyService {
     }
   }
 
-  public async searchTerm(termSetId: Guid, label: string, languageTag: string, parentTermId?: Guid, allowSelectingChildren = true, stringMatchId: string = '0', pageSize: number = 50): Promise<ITermInfo[]> {
+  public async searchTerm(termSetId: Guid, label: string, languageTag: string, parentTermId?: Guid, allowSelectingChildren = true, stringMatchOption: string = 'StartsWith', pageSize: number = 50): Promise<ITermInfo[]> {
     try {
       const query = [
         `label='${label}'`,
         `setId='${termSetId}'`,
         `languageTag='${languageTag}'`,
-        `stringMatchId='${stringMatchId}'`
+        `stringMatchOption='${stringMatchOption}'`
       ];
 
       if(parentTermId !== Guid.empty) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1688

#### What's in this Pull Request?

As discussed in #1688 it appears that the `stringMatchId` query parameter is not supported by the searchTerm-API anymore. The fix proposed in that issue (using the `stringMatchOption` query parameter with value `StartsWith`) worked.

With VS Code I could not find any usages of the `searchTerm` function that uses the `stringMatchId`, so there are (hopefully) no side effects in the package itself. For consuming libraries, this might be a breaking change.