### PR TITLE
Fixing issue #1717

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -597,7 +597,7 @@ export class DynamicForm extends React.Component<
             hiddenName = response.value;
             termSetId = field.TermSetId;
             anchorId = field.AnchorId;
-            if (item !== null && item[field.InternalName] !== null && item[field.InternalName].results !== null) {
+            if (item && item[field.InternalName] && item[field.InternalName].results) {
               item[field.InternalName].results.forEach((element) => {
                 selectedTags.push({
                   key: element.TermGuid,
@@ -606,8 +606,17 @@ export class DynamicForm extends React.Component<
               });
 
               defaultValue = selectedTags;
+            } else if (defaultValue && defaultValue.results) {
+              defaultValue.results.forEach((element) => {
+                selectedTags.push({
+                  key: element.TermGuid,
+                  name: element.Label,
+                });
+              });
+
+              defaultValue = selectedTags;
             } else {
-              if (defaultValue !== null && defaultValue !== "") {
+              if (defaultValue && defaultValue !== "") {
                 defaultValue.split(/#|;/).forEach((element) => {
                   if (element.indexOf("|") !== -1)
                     selectedTags.push({


### PR DESCRIPTION
Previous fix for #1568 was incomplete. New expanded fix for #1717. DefaultValue can be an object too.

| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1717

#### What's in this Pull Request?

Additional check to see if DefaultValue is an object. No more null comparissons, which should have been undefined comparissons.

