### PR TITLE
ISSUE 1683 Fix: (DynamicForm) Added the option to edit file name

### DIFF
--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -525,6 +525,24 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
           {descriptionEl}
           {errorTextEl}
         </div>;
+
+        case 'File':
+          return <div>
+            <div className={styles.titleContainer}>
+              <Icon className={styles.fieldIcon} iconName={"Page"} />
+              {labelEl}
+            </div>
+            <TextField
+              defaultValue={defaultValue}
+              placeholder={placeholder}
+              className={styles.fieldDisplay}
+              onChange={(e, newText) => { this.onChange(newText); }}
+              disabled={disabled}
+              onBlur={this.onBlur}
+              errorMessage={errorText}
+            />
+            {descriptionEl}
+          </div>;
     }
 
     return null;

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -793,4 +793,24 @@ export default class SPService implements ISPService {
       resolve(listData);
     });
   }
+
+  public async getFileName(listId: string, itemId: number, webUrl?: string): Promise<string> { 
+    try {
+      const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
+
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(${itemId})?@listId=guid'${encodeURIComponent(listId)}'&$select=FileLeafRef`;
+      const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
+      if (data.ok) {
+        const results = await data.json();
+        if (results) {
+          return results.FileLeafRef;
+        }
+      }
+
+      return null;
+    } catch (error) {
+      console.dir(error);
+      return Promise.reject(error);
+    }
+  }
 }


### PR DESCRIPTION
Added the option to edit file name when the form points to a document library and an item is being edited

| Q               | A
| --------------- | ---
| Bug fix?        | [ X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1683 

#### What's in this Pull Request?

When the control DynamicForm is configured to display an item in a document library, the field Name (FileLeafRef) does not come through to edit.

To amend that behaviour, I have performed the following changes:

_DynamicForm.tsx_
- The function that retrieves the fields (getFormFields) has been modified to bring the field FileLeafRef when an item id has been provided (hence editing an item)
- The function that provides the information needed to display the fields (getFieldInformations) has been modified to include a case for File fields and retrieve the file name

_DynamicField.tsx_
- A new case has been added to display a File field by displaying a text box with the file name

_SPService.ts_
- A new function has been added to SPService to retrieve the file name of a document library item (getFileName)


