### PR TITLE
[DynamicForm] Fixing multi taxonomy field (loading + saving existing item)

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -415,7 +415,7 @@ export class DynamicForm extends React.Component<
         if (field.newValue !== null && field.newValue !== undefined) {
 
           let value = field.newValue;
-          if (["Lookup", "LookupMulti", "User", "UserMulti"].indexOf(fieldType) < 0) {
+          if (["Lookup", "LookupMulti", "User", "UserMulti", "TaxonomyFieldTypeMulti"].indexOf(fieldType) < 0) {
             objects[columnInternalName] = value;
           }
 
@@ -1200,7 +1200,7 @@ export class DynamicForm extends React.Component<
               });
             });
 
-            defaultValue = selectedTags;
+            value = selectedTags;
           } else {
             if (defaultValue && defaultValue !== "") {
               defaultValue.split(/#|;/).forEach((element) => {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]

#### What's in this Pull Request?

This PR fixes two issues regarding DynamicForm, especially multi taxonomy field.

First one when loading an existing item, taxonomy field displays blank values:

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/44271458/2d979be9-eb1a-4ebc-83f0-ddabee4e2b8e)

The second one occurs when saving the existing item (after fixing previous issue), structure of payload is wrong, which causes this issue:

![image](https://github.com/pnp/sp-dev-fx-controls-react/assets/44271458/2f8f4134-bc77-4552-b825-9de4aaffc4ac)

_"A node of type 'StartArray' was read from the JSON reader when trying to read a value of a property; however, a 'PrimitiveValue' or 'StartObject' node was expected."_
