### PR TITLE
Fixing Issue - 1669 - PeoplePicker returns no results with webAbsoluteUrl and ensureUser

### DIFF
--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -282,6 +282,9 @@ export default class SPPeopleSearchService {
       if (userIdx !== -1) {
         return users[userIdx].Id;
       }
+    } //initialize the array if it doesnt exist with the siteUrl
+    else if(!this.cachedLocalUsers[siteUrl]) {
+      this.cachedLocalUsers[siteUrl] = [];
     }
 
     const restApi = `${siteUrl}/_api/web/ensureuser`;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1669 

#### What's in this Pull Request?
Fixing issue - 1669 - PeoplePicker returns no results with webAbsoluteUrl and ensureUser

#### Problem statement
When setting webAbsoluteUrl prop to a different site and property to ensureUser = true, results are expected to be returned.
But, No results are fetched, If both the webAbsoluteUrl prop is pointing to a different site than the current one, and ensureUser is set to true, no results are returned in the picker. Instead, the console shows the error: PeopleSearchService::searchTenant: error occured while fetching the users.

![272968786-c5580105-3c8c-4551-b143-28220b756b01](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/54b9ff34-3cd8-4def-90af-2d71b999275d)

A deeper error says Cannot read properties of undefined (reading 'push'), which I've tracked down to PeopleSearchService.ensureUser:295. The object cachedLocalUsers assumes it already contains the webAbsoluteUrl as a key but it does not.

#### Solution
When checked, in the method ensureUser, the user object is pushed into `this.cachedLocalUsers`. But this is empty because the user is given `webAbsoluteUrl` to fetch the users from other site collection, for which it is erroring out as `Cannot read properties of undefined (reading push)` as shown in the below figure.

<img width="419" alt="image" src="https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/758093b2-2c23-4d77-83bd-8ea8bef9264a">

By checking if `this.cachedLocalUsers` and initializing it as empty array (as below), this is working as expected. 

<img width="571" alt="image" src="https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/4ec163e6-fef9-4f45-9393-c7314087e608">

#### Screenshot with working example

![Issue 1669](https://github.com/pnp/sp-dev-fx-controls-react/assets/47456098/e54ca3b6-273c-4491-8532-1ac226ac63fd)


Thanks,
Nishkalank Bezawada
