### PR TITLE
Added orderBy to DynamicField props for lookup fields

### DIFF
--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -79,7 +79,8 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       principalType,
       description,
       maximumValue,
-      minimumValue
+      minimumValue,
+      orderBy
     } = this.props;
 
     const {
@@ -237,6 +238,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
             itemLimit={1}
             onSelectedItem={(newValue) => { this.onChange(newValue, true); }}
             context={context}
+            orderBy={orderBy}
           />
           {descriptionEl}
           {errorTextEl}
@@ -283,8 +285,8 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
             onChange={(e, newText) => { this.onChange(newText); }}
             disabled={disabled}
             onBlur={this.onBlur}
-            errorMessage={errorText || customNumberErrorMessage} 
-            min={minimumValue} 
+            errorMessage={errorText || customNumberErrorMessage}
+            min={minimumValue}
             max={maximumValue} />
           {descriptionEl}
         </div>;
@@ -306,8 +308,8 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
             onChange={(e, newText) => { this.onChange(newText); }}
             disabled={disabled}
             onBlur={this.onBlur}
-            errorMessage={errorText || customNumberErrorMessage} 
-            min={minimumValue} 
+            errorMessage={errorText || customNumberErrorMessage}
+            min={minimumValue}
             max={maximumValue} />
           {descriptionEl}
         </div>;
@@ -687,7 +689,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       }
       else {
         // selectedItemArr = this.props.value;
-        selectedItemArr = !changedValue ? [] : 
+        selectedItemArr = !changedValue ? [] :
         ( Array.isArray(changedValue) ? [ ...changedValue ] : [ changedValue] );
       }
 

--- a/src/controls/dynamicForm/dynamicField/IDynamicFieldProps.ts
+++ b/src/controls/dynamicForm/dynamicField/IDynamicFieldProps.ts
@@ -7,41 +7,46 @@ export type FieldChangeAdditionalData = IFilePickerResult;
 
 export interface IDynamicFieldProps {
   context: BaseComponentContext;
-  
+
   /** Internal column name */
   columnInternalName: string;
   cultureName?: string;
-  
+
   /** SharePoint Field Type */
   fieldType: string;
-  
+
   /** Text label for field */
   label?: string;
-  
+
   /** Placeholder text for field */
   placeholder?: string;
-  
+
   /** Specifies if a field should be filled in order to pass validation */
   required: boolean;
-  
+
   /** Specifies if a field should be disabled */
   disabled?: boolean;
-  
+
   /** List Item Id, passed to various utility/helper functions to determine things like selected User UPN, Lookup text, Term labels etc. */
   listItemId?: number;
-  
+
   /** The default value of the field. */
   defaultValue: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   /** Holds a field value. Set on all fields in the form. */
   value?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  
+
   /** Fired by DynamicField when a field value is changed */
-  onChanged?: (columnInternalName: string, newValue: any, validate: boolean, additionalData?: FieldChangeAdditionalData) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  onChanged?: (
+    columnInternalName: string,
+    newValue: any,
+    validate: boolean,
+    additionalData?: FieldChangeAdditionalData
+  ) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   /** Represents the value of the field as updated by the user. Only updated by fields when changed. */
   newValue?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  
+
   /** Represents a stringified value of the field. Used in custom formatting and validation. */
   stringValue: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -50,7 +55,7 @@ export interface IDynamicFieldProps {
 
   /** If validation raises an error message, it can be stored against the field here for display by DynamicField  */
   validationErrorMessage?: string;
-  
+
   /** Field Term Set ID, used in Taxonomy / Metadata fields */
   fieldTermSetId?: string;
 
@@ -64,16 +69,16 @@ export interface IDynamicFieldProps {
   lookupField?: string;
 
   // changedValue: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  
+
   /** Equivalent to HiddenListInternalName, used for Taxonomy Metadata fields */
   hiddenFieldName?: string;
-  
+
   /** Order of the field in the form */
   Order: number;
-  
+
   /** Used for files / image uploads */
   additionalData?: FieldChangeAdditionalData;
-  
+
   // Related to various field types
   options?: IDropdownOption[];
   isRichText?: boolean;
@@ -84,4 +89,5 @@ export interface IDynamicFieldProps {
   maximumValue?: number;
   minimumValue?: number;
   showAsPercentage?: boolean;
+  orderBy?: string;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]

#### What's in this Pull Request?

Added __orderBy__ property on the __DynamicField__ control to allow sorting when using directly the __DynamicField__ control.

For example if you have a __DynamicForm__ and you want to declare a custom sorting for lookup _TargetField_ you can do the following:

```Typescript
private _customRenderTargetField = (fieldProperties: IDynamicFieldProps): React.ReactElement<IDynamicFieldProps> => {
  return <DynamicField
      key="TargetField"
      {...fieldProperties}
      orderBy={"Title desc"}
      />;
}
```

