### PR TITLE
#1135: Richtext control, can not undo ordered lists 

### DIFF
--- a/src/controls/filePicker/LinkFilePickerTab/LinkFilePickerTab.tsx
+++ b/src/controls/filePicker/LinkFilePickerTab/LinkFilePickerTab.tsx
@@ -34,6 +34,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
             className={styles.linkTextField}
             label={strings.LinkFileInstructions}
             ariaLabel={strings.LinkFileInstructions}
+            defaultValue={"https://"}
             onGetErrorMessage={(value: string) => this._getErrorMessagePromise(value)}
             autoAdjustHeight={false}
             underlined={false}
@@ -63,7 +64,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
    * Called as user types in a new value
    */
   private _handleChange = (fileUrl: string): void => {
-    const filePickerResult: IFilePickerResult = fileUrl ? {
+    const filePickerResult: IFilePickerResult = fileUrl && this._isUrl(fileUrl) ? {
       fileAbsoluteUrl: fileUrl,
       fileName: GeneralHelper.getFileNameFromUrl(fileUrl),
       fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(fileUrl),
@@ -80,7 +81,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
    */
   private _getErrorMessagePromise = async (value: string): Promise<string> => {
     // DOn't give an error for blank or placeholder value, but don't make it a valid entry either
-    if (value === undefined || value === '') {
+    if (value === undefined || value === 'https://') {
       this.setState({ isValid: false });
       return '';
     }
@@ -88,7 +89,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
     // Make sure that user is typing a valid URL format
     if (!this._isUrl(value)) {
       this.setState({ isValid: false });
-      return strings.InvalidUrlError;
+      return '';
     }
 
     // If we don't allow external links, verify that we're in the same domain

--- a/src/controls/filePicker/LinkFilePickerTab/LinkFilePickerTab.tsx
+++ b/src/controls/filePicker/LinkFilePickerTab/LinkFilePickerTab.tsx
@@ -34,7 +34,6 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
             className={styles.linkTextField}
             label={strings.LinkFileInstructions}
             ariaLabel={strings.LinkFileInstructions}
-            defaultValue={"https://"}
             onGetErrorMessage={(value: string) => this._getErrorMessagePromise(value)}
             autoAdjustHeight={false}
             underlined={false}
@@ -64,7 +63,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
    * Called as user types in a new value
    */
   private _handleChange = (fileUrl: string): void => {
-    const filePickerResult: IFilePickerResult = fileUrl && this._isUrl(fileUrl) ? {
+    const filePickerResult: IFilePickerResult = fileUrl ? {
       fileAbsoluteUrl: fileUrl,
       fileName: GeneralHelper.getFileNameFromUrl(fileUrl),
       fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(fileUrl),
@@ -81,7 +80,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
    */
   private _getErrorMessagePromise = async (value: string): Promise<string> => {
     // DOn't give an error for blank or placeholder value, but don't make it a valid entry either
-    if (value === undefined || value === 'https://') {
+    if (value === undefined || value === '') {
       this.setState({ isValid: false });
       return '';
     }
@@ -89,7 +88,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
     // Make sure that user is typing a valid URL format
     if (!this._isUrl(value)) {
       this.setState({ isValid: false });
-      return '';
+      return strings.InvalidUrlError;
     }
 
     // If we don't allow external links, verify that we're in the same domain

--- a/src/controls/richText/RichText.tsx
+++ b/src/controls/richText/RichText.tsx
@@ -695,7 +695,7 @@ export class RichText extends React.Component<IRichTextProps, IRichTextState> {
   private onChangeList = (_event: React.FormEvent<HTMLDivElement>, item?: IDropdownOption, _index?: number): void => {
     // if we're already in list mode, toggle off
     const key = item.key;
-    const newAlignValue = (key === 'bullet' && this.state.formats.list === 'bullet') || (key === 'numbered' && this.state.formats.list === 'numbered') ? false : key;
+    const newAlignValue = (key === 'bullet' && this.state.formats.list === 'bullet') || (key === 'ordered' && this.state.formats.list === 'ordered') ? false : key;
     this.applyFormat("list", newAlignValue);
   }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1135

#### What's in this Pull Request?
Fixed issue with ordered list on Richtext webpart.
Dropdown option's list had key 'ordered' and onChange function had 'numbered' key. 
Changed key in function to 'ordered'.