### PR TITLE
IWidgetLink improvements

### DIFF
--- a/docs/documentation/docs/controls/Dashboard.md
+++ b/docs/documentation/docs/controls/Dashboard.md
@@ -142,6 +142,9 @@ Provides Widget link properties
 | Property | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
 | href | string | yes | Link to be opened. |
+| title | string | no | The text to display for the link, if not provided, the default text will be used. |
+| color | string | no | The color of the link, if not provided, the default brand color will be used. |
+| target | string | no | The target property value for the generated anchor tag, if not provided, the default target will be *_blank*. |
 
 Enum `WidgetSize`
 

--- a/docs/documentation/docs/controls/Dashboard.md
+++ b/docs/documentation/docs/controls/Dashboard.md
@@ -22,6 +22,12 @@ import { WidgetSize, Dashboard } from '@pnp/spfx-controls-react/lib/Dashboard';
 
 ```TypeScript
 const linkExample = { href: "#" };
+const customizedLinkExample = {
+      href: "#",
+      title: "This is a customized link!",
+      color: "red",
+      target: "_top"
+    };
 const calloutItemsExample = [
   {
     id: "action_1",
@@ -71,7 +77,7 @@ const calloutItemsExample = [
   {
     title: "Card 2",
     size: WidgetSize.Single,
-    link: linkExample,
+    link: customizedLinkExample,
   },
   {
     title: "Card 3",
@@ -143,7 +149,7 @@ Provides Widget link properties
 | ---- | ---- | ---- | ---- |
 | href | string | yes | Link to be opened. |
 | title | string | no | The text to display for the link, if not provided, the default text will be used. |
-| color | string | no | The color of the link, if not provided, the default brand color will be used. |
+| color | string | no | The color of the link, if not provided, the "default" color will be used. The available colors can be found on the [official Fluent UI documentation of the Text control](https://fluentsite.z22.web.core.windows.net/0.66.2/components/text/definition#variations-color). |
 | target | string | no | The target property value for the generated anchor tag, if not provided, the default target will be *_blank*. |
 
 Enum `WidgetSize`

--- a/src/controls/dashboard/widget/IWidget.ts
+++ b/src/controls/dashboard/widget/IWidget.ts
@@ -97,7 +97,7 @@ export interface IWidgetBodyContent {
  */
 export interface IWidgetLink {
   /**
-   * Link href
+   * Link to be opened
    */
   href: string;
   /**
@@ -105,7 +105,7 @@ export interface IWidgetLink {
    */
   title?: string;
   /**
-   * The color of the link, if not provided, the default color will be used
+   * The color of the link, if not provided, the "brand" color will be used. The available colors can be found on the [official Fluent UI documentation of the Text control](https://fluentsite.z22.web.core.windows.net/0.66.2/components/text/definition#variations-color)
    */
   color?: string;
   /**

--- a/src/controls/dashboard/widget/IWidget.ts
+++ b/src/controls/dashboard/widget/IWidget.ts
@@ -96,5 +96,20 @@ export interface IWidgetBodyContent {
  * Widget link
  */
 export interface IWidgetLink {
+  /**
+   * Link href
+   */
   href: string;
+  /**
+   * The text to display for the link, if not provided, the default text will be used
+   */
+  title?: string;
+  /**
+   * The color of the link, if not provided, the default color will be used
+   */
+  color?: string;
+  /**
+   * The target for the generated anchor tag, if not provided, the default target will be _blank
+   */
+  target?: "_blank" | "_self" | "_parent" | "_top" | "framename";
 }

--- a/src/controls/dashboard/widget/WidgetFooter.tsx
+++ b/src/controls/dashboard/widget/WidgetFooter.tsx
@@ -12,7 +12,7 @@ export const WidgetFooter = ({ widget }: { widget: IWidget }): JSX.Element => (
                 target={widget.link.target ?? "_blank"}
                 content={widget.link.title ?? strings.ViewMore}
                 size="small"
-                color={widget.link.color ?? "brand"}
+                color={widget.link.color ?? "default"}
                 style={{ textDecoration: "none" }}
             />
         </Flex>

--- a/src/controls/dashboard/widget/WidgetFooter.tsx
+++ b/src/controls/dashboard/widget/WidgetFooter.tsx
@@ -9,10 +9,10 @@ export const WidgetFooter = ({ widget }: { widget: IWidget }): JSX.Element => (
             <Text
                 as="a"
                 href={widget.link.href}
-                target="_blank"
-                content={strings.ViewMore}
+                target={widget.link.target ?? "_blank"}
+                content={widget.link.title ?? strings.ViewMore}
                 size="small"
-                color="brand"
+                color={widget.link.color ?? "brand"}
                 style={{ textDecoration: "none" }}
             />
         </Flex>

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -903,6 +903,12 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
     }];
 
     const linkExample = { href: "#" };
+    const customizedLinkExample = {
+      href: "#",
+      title: "This is a customized link!",
+      color: "red",
+      target: "_top"
+    };
     const calloutItemsExample = [
       {
         id: "action_1",
@@ -2034,7 +2040,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             {
               title: "Card 2",
               size: WidgetSize.Single,
-              link: linkExample,
+              link: customizedLinkExample,
             },
             {
               title: "Card 3",
@@ -2044,7 +2050,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
             {
               title: "Card 4",
               size: WidgetSize.Single,
-              link: linkExample,
+              link: customizedLinkExample,
             },
             {
               title: "Card 5",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]

#### What's in this Pull Request?

Added new properties to the **IWidgetLink** interface to allow more customization options.
The new properties are:
- **title**: to enable the change of the default text of the link.
- **color**: custom color, if not specified the "brand" one will be used.
- **target**: specify an alternative target property for the generated anchor tag, the default remains __blank_.
