### PR TITLE
#1101: Fix issue with adding link by typing in FilePicker "From a link" tab

### DIFF
--- a/src/controls/filePicker/LinkFilePickerTab/LinkFilePickerTab.tsx
+++ b/src/controls/filePicker/LinkFilePickerTab/LinkFilePickerTab.tsx
@@ -34,7 +34,6 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
             className={styles.linkTextField}
             label={strings.LinkFileInstructions}
             ariaLabel={strings.LinkFileInstructions}
-            defaultValue={"https://"}
             onGetErrorMessage={(value: string) => this._getErrorMessagePromise(value)}
             autoAdjustHeight={false}
             underlined={false}
@@ -64,7 +63,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
    * Called as user types in a new value
    */
   private _handleChange = (fileUrl: string): void => {
-    const filePickerResult: IFilePickerResult = fileUrl && this._isUrl(fileUrl) ? {
+    const filePickerResult: IFilePickerResult = fileUrl ? {
       fileAbsoluteUrl: fileUrl,
       fileName: GeneralHelper.getFileNameFromUrl(fileUrl),
       fileNameWithoutExtension: GeneralHelper.getFileNameWithoutExtension(fileUrl),
@@ -81,7 +80,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
    */
   private _getErrorMessagePromise = async (value: string): Promise<string> => {
     // DOn't give an error for blank or placeholder value, but don't make it a valid entry either
-    if (value === undefined || value === 'https://') {
+    if (value === undefined || value === '') {
       this.setState({ isValid: false });
       return '';
     }
@@ -89,7 +88,7 @@ export default class LinkFilePickerTab extends React.Component<ILinkFilePickerTa
     // Make sure that user is typing a valid URL format
     if (!this._isUrl(value)) {
       this.setState({ isValid: false });
-      return '';
+      return strings.InvalidUrlError;
     }
 
     // If we don't allow external links, verify that we're in the same domain


### PR DESCRIPTION
…k" tab

| Q               | A
| --------------- | ---
| Bug fix?        | [x ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1101

#### What's in this Pull Request?
Fixed issue with typing url in FilePicker control "From a link" tab.
Added error message if value is an invalid url.
Removed '"defaultValue" in TextFiend, because it doesn't affect controlled components.
