### PR TITLE
FilePicker - Fixing organization tab browsing issue

### DIFF
--- a/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
+++ b/src/controls/filePicker/SiteFilePickerTab/SiteFilePickerTab.tsx
@@ -28,7 +28,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
       key: props.webId || props.context.pageContext.web.id.toString(),
     };
     // add click event after defining breadcrumb so that it also applies to breadcrumb items passed to the component as properties
-    breadcrumbSiteNode.onClick = (ev, itm) => { this.onBreadcrumpItemClick(itm); };
+    breadcrumbSiteNode.onClick = (ev, itm) => { this.onBreadcrumbItemClick(itm); };
 
     const breadcrumbItems: FilePickerBreadcrumbItem[] = [breadcrumbSiteNode];
 
@@ -57,100 +57,6 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
       folderName: strings.DocumentLibraries,
       breadcrumbItems
     };
-  }
-
-  private _parseInitialLocationState(folderAbsPath: string, { serverRelativeUrl: webServRelUrl, absoluteUrl: webAbsUrl }): {
-    libraryServRelUrl: string;
-    folderServRelPath: string;
-    folderAbsPath: string;
-    folderBreadcrumbs: FilePickerBreadcrumbItem[];
-  } {
-    // folderAbsPath: "https://tenant.sharepoint.com/teams/Test/DocLib/Folder"
-
-    // folderServRelPath: "/teams/Test/DocLib/Folder"
-    let folderServRelPath = folderAbsPath && folderAbsPath.substr(folderAbsPath.indexOf(webServRelUrl));
-
-    // folderAbsPath: "https://tenant.sharepoint.com/DocLib/Folder"
-    if (webServRelUrl === "/") {
-      folderServRelPath = folderAbsPath && folderAbsPath.split(webAbsUrl)[1];
-    }
-
-    // folderWebRelPath: "/DocLib/Folder"
-    const folderWebRelPath = folderServRelPath && folderServRelPath.substr(webServRelUrl.length);
-    let libInternalName = folderWebRelPath && folderWebRelPath.substring(1, Math.max(folderWebRelPath.indexOf("/", 2), 0) || undefined);
-    if (webServRelUrl === "/") {
-      libInternalName = folderWebRelPath && folderWebRelPath.substring(0, Math.max(folderWebRelPath.indexOf("/", 2), 0) || undefined);
-    }
-
-    // libraryServRelUrl: "/teams/Test/DocLib/"
-    const libraryServRelUrl = urlCombine(webServRelUrl, libInternalName);
-
-    let tenantUrl = folderAbsPath.substring(0, folderAbsPath.indexOf(webServRelUrl));
-    if (webAbsUrl === "/") {
-      tenantUrl = webAbsUrl;
-    }
-    const folderBreadcrumbs: FilePickerBreadcrumbItem[] = this.parseBreadcrumbsFromPaths(
-      libraryServRelUrl,
-      folderServRelPath,
-      folderWebRelPath,
-      webAbsUrl,
-      tenantUrl,
-      libInternalName,
-      webServRelUrl
-    );
-
-    return { libraryServRelUrl, folderServRelPath, folderAbsPath, folderBreadcrumbs };
-  }
-
-  private parseBreadcrumbsFromPaths(
-    libraryServRelUrl: string,
-    folderServRelPath: string,
-    folderWebRelPath: string,
-    webAbsUrl: string,
-    tenantUrl: string,
-    libInternalName: string,
-    webServRelUrl: string
-  ): FilePickerBreadcrumbItem[] {
-    this._defaultLibraryNamePromise = this.props.fileBrowserService.getLibraryNameByInternalName(libInternalName);
-    const folderBreadcrumbs: FilePickerBreadcrumbItem[] = [];
-    folderBreadcrumbs.push({
-      isCurrentItem: false,
-      text: libInternalName,
-      key: libraryServRelUrl,
-      libraryData: {
-        serverRelativeUrl: libraryServRelUrl,
-        absoluteUrl: urlCombine(webAbsUrl, libInternalName),
-        title: libInternalName
-      },
-      onClick: (ev, itm) => { this.onBreadcrumpItemClick(itm); }
-    });
-
-    if (folderServRelPath !== libraryServRelUrl) {
-      let folderLibRelPath = folderWebRelPath.substring(libInternalName.length + 2);
-      if (webServRelUrl === "/") {
-        folderLibRelPath = folderWebRelPath.substring(libInternalName.length + 1);
-      }
-
-      let breadcrumbFolderServRelPath = libraryServRelUrl;
-
-      const crumbs: FilePickerBreadcrumbItem[] = folderLibRelPath.split("/").map((currFolderName => {
-        breadcrumbFolderServRelPath += `/${currFolderName}`;
-        return {
-          isCurrentItem: false,
-          text: currFolderName,
-          key: urlCombine(tenantUrl, breadcrumbFolderServRelPath),
-          folderData: {
-            name: currFolderName,
-            absoluteUrl: urlCombine(tenantUrl, breadcrumbFolderServRelPath),
-            serverRelativeUrl: breadcrumbFolderServRelPath,
-          },
-          onClick: (ev, itm) => { this.onBreadcrumpItemClick(itm); }
-        };
-      }));
-
-      folderBreadcrumbs.push(...crumbs);
-    }
-    return folderBreadcrumbs;
   }
 
   public componentDidMount(): void {
@@ -208,9 +114,9 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
   }
 
   /**
-   * Handles breadcrump item click
+   * Handles breadcrumb item click
    */
-  private onBreadcrumpItemClick = (node: FilePickerBreadcrumbItem): void => {
+  private onBreadcrumbItemClick = (node: FilePickerBreadcrumbItem): void => {
     let { breadcrumbItems } = this.state;
     let breadcrumbClickedItemIndx = 0;
     // Site node clicked
@@ -282,7 +188,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
         isCurrentItem: true,
         text: folder.name,
         key: folder.absoluteUrl,
-        onClick: (ev, itm) => { this.onBreadcrumpItemClick(itm); }
+        onClick: (ev, itm) => { this.onBreadcrumbItemClick(itm); }
       };
       breadcrumbItems.push(breadcrumbNode);
     }
@@ -308,7 +214,7 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
         isCurrentItem: true,
         text: library.title,
         key: library.serverRelativeUrl,
-        onClick: (ev, itm) => { this.onBreadcrumpItemClick(itm); }
+        onClick: (ev, itm) => { this.onBreadcrumbItemClick(itm); }
       };
       breadcrumbItems.push(breadcrumbNode);
     }
@@ -318,5 +224,116 @@ export default class SiteFilePickerTab extends React.Component<ISiteFilePickerTa
       libraryPath: library.serverRelativeUrl,
       breadcrumbItems
     });
+  }
+
+  /**
+   * Initializes the initial location for the navigation
+   * @param folderAbsPath Absolute folder path
+   * @param param1 custom object with absolute & relative Url
+   * @returns initial location parameters set
+   */
+  private _parseInitialLocationState(folderAbsPath: string, { serverRelativeUrl: webServRelUrl, absoluteUrl: webAbsUrl }): {
+    libraryServRelUrl: string;
+    folderServRelPath: string;
+    folderAbsPath: string;
+    folderBreadcrumbs: FilePickerBreadcrumbItem[];
+  } {
+    // folderAbsPath: "https://tenant.sharepoint.com/teams/Test/DocLib/Folder"
+
+    // folderServRelPath: "/teams/Test/DocLib/Folder"
+    let folderServRelPath = folderAbsPath && folderAbsPath.substr(folderAbsPath.indexOf(webServRelUrl));
+
+    // folderAbsPath: "https://tenant.sharepoint.com/DocLib/Folder"
+    if (webServRelUrl === "/") {
+      folderServRelPath = folderAbsPath && folderAbsPath.split(webAbsUrl)[1];
+    }
+
+    // folderWebRelPath: "/DocLib/Folder"
+    const folderWebRelPath = folderServRelPath && folderServRelPath.substr(webServRelUrl.length);
+    let libInternalName = folderWebRelPath && folderWebRelPath.substring(1, Math.max(folderWebRelPath.indexOf("/", 2), 0) || undefined);
+    if (webServRelUrl === "/") {
+      libInternalName = folderWebRelPath && folderWebRelPath.substring(0, Math.max(folderWebRelPath.indexOf("/", 2), 0) || undefined);
+    }
+
+    // libraryServRelUrl: "/teams/Test/DocLib/"
+    const libraryServRelUrl = urlCombine(webServRelUrl, libInternalName);
+
+    let tenantUrl = folderAbsPath.substring(0, folderAbsPath.indexOf(webServRelUrl));
+    if (webAbsUrl === "/") {
+      tenantUrl = webAbsUrl;
+    }
+    const folderBreadcrumbs: FilePickerBreadcrumbItem[] = this.parseBreadcrumbsFromPaths(
+      libraryServRelUrl,
+      folderServRelPath,
+      folderWebRelPath,
+      webAbsUrl,
+      tenantUrl,
+      libInternalName,
+      webServRelUrl
+    );
+
+    return { libraryServRelUrl, folderServRelPath, folderAbsPath, folderBreadcrumbs };
+  }
+
+  /**
+   * Creates a breadcrumb from the paths
+   * @param libraryServRelUrl Library server relative URL
+   * @param folderServRelPath Folder server relative path
+   * @param folderWebRelPath Folder web relative path
+   * @param webAbsUrl Web absolute URL
+   * @param tenantUrl Tenant URL
+   * @param libInternalName Library internal name
+   * @param webServRelUrl Web server relative URL 
+   * @returns Breadcrumb items 
+   */
+  private parseBreadcrumbsFromPaths(
+    libraryServRelUrl: string,
+    folderServRelPath: string,
+    folderWebRelPath: string,
+    webAbsUrl: string,
+    tenantUrl: string,
+    libInternalName: string,
+    webServRelUrl: string
+  ): FilePickerBreadcrumbItem[] {
+    this._defaultLibraryNamePromise = this.props.fileBrowserService.getLibraryNameByInternalName(libInternalName);
+    const folderBreadcrumbs: FilePickerBreadcrumbItem[] = [];
+    folderBreadcrumbs.push({
+      isCurrentItem: false,
+      text: libInternalName,
+      key: libraryServRelUrl,
+      libraryData: {
+        serverRelativeUrl: libraryServRelUrl,
+        absoluteUrl: urlCombine(webAbsUrl, libInternalName),
+        title: libInternalName
+      },
+      onClick: (ev, itm) => { this.onBreadcrumbItemClick(itm); }
+    });
+
+    if (folderServRelPath !== libraryServRelUrl) {
+      let folderLibRelPath = folderWebRelPath.substring(libInternalName.length + 2);
+      if (webServRelUrl === "/") {
+        folderLibRelPath = folderWebRelPath.substring(libInternalName.length + 1);
+      }
+
+      let breadcrumbFolderServRelPath = libraryServRelUrl;
+
+      const crumbs: FilePickerBreadcrumbItem[] = folderLibRelPath.split("/").map((currFolderName => {
+        breadcrumbFolderServRelPath += `/${currFolderName}`;
+        return {
+          isCurrentItem: false,
+          text: currFolderName,
+          key: urlCombine(tenantUrl, breadcrumbFolderServRelPath),
+          folderData: {
+            name: currFolderName,
+            absoluteUrl: urlCombine(tenantUrl, breadcrumbFolderServRelPath),
+            serverRelativeUrl: breadcrumbFolderServRelPath,
+          },
+          onClick: (ev, itm) => { this.onBreadcrumbItemClick(itm); }
+        };
+      }));
+
+      folderBreadcrumbs.push(...crumbs);
+    }
+    return folderBreadcrumbs;
   }
 }

--- a/src/services/OrgAssetsService.ts
+++ b/src/services/OrgAssetsService.ts
@@ -3,29 +3,35 @@ import { BaseComponentContext } from '@microsoft/sp-component-base';
 import { SPHttpClient } from "@microsoft/sp-http";
 import { ILibrary, FilesQueryResult } from "./FileBrowserService.types";
 
+/**
+ * OrgAssetsService class
+ */
 export class OrgAssetsService extends FileBrowserService {
+  // Site organization assets library server relative URL
   private _orgAssetsLibraryServerRelativeSiteUrl: string = null;
 
+  /**
+   * Constructor
+   * @param context Component context
+   * @param itemsToDownloadCount Items to download count
+   */
   constructor(context: BaseComponentContext, itemsToDownloadCount?: number) {
     super(context, itemsToDownloadCount);
   }
 
-  public getListItems = async (listUrl: string, folderPath: string, acceptedFilesExtensions?: string[], nextPageQueryStringParams?: string): Promise<FilesQueryResult> => {
+  /**
+   * Gets files from current sites library
+   * @param _listUrl Unused parameter (not used in this implementation)
+   * @param folderPath Folder path to get items from
+   * @param acceptedFilesExtensions File extensions to filter the results
+   * @param nextPageQueryStringParams Query string parameters to get the next page of results
+   * @returns Items in the specified folder
+   */
+  public getListItems = async (_listUrl: string, folderPath: string, acceptedFilesExtensions?: string[], nextPageQueryStringParams?: string): Promise<FilesQueryResult> => {
     let filesQueryResult: FilesQueryResult = { items: [], nextHref: null };
     try {
-
-      // Retrieve Lib path from folder path
-      const isRootSite = this.context.pageContext.site.serverRelativeUrl === '/';
-
-      if (!isRootSite) {
-        if (folderPath.charAt(0) !== '/') {
-          folderPath = `/${folderPath}`;
-        }
-
-      } else {
-        if (folderPath.charAt(0) === '/') {
-          folderPath = folderPath.substring(1);
-        }
+      if (folderPath.charAt(0) !== '/') {
+        folderPath = `/${folderPath}`;
       }
 
       // Remove all the rest of the folder path
@@ -33,7 +39,7 @@ export class OrgAssetsService extends FileBrowserService {
       libName = libName.split('/')[0];
 
       // Build absolute library URL
-      const libFullUrl = this.buildAbsoluteUrl(!isRootSite ? `${this._orgAssetsLibraryServerRelativeSiteUrl}/${libName}` : `${this._orgAssetsLibraryServerRelativeSiteUrl}${libName}`);
+      const libFullUrl = this.buildAbsoluteUrl(`${this._orgAssetsLibraryServerRelativeSiteUrl}/${libName}`);
 
       let queryStringParams: string = "";
       // Do not pass FolderServerRelativeUrl as query parameter
@@ -57,6 +63,11 @@ export class OrgAssetsService extends FileBrowserService {
     return filesQueryResult;
   }
 
+  /**
+   * Gets document and media libraries from the site
+   * @param includePageLibraries Unused parameter (not used in this implementation)
+   * @returns Document and media libraries from the site 
+   */
   public getSiteMediaLibraries = async (includePageLibraries: boolean = false): Promise<ILibrary[]> => {
     try {
       const restApi = `${this.context.pageContext.web.absoluteUrl}/_api/SP.Publishing.SitePageService.FilePickerTabOptions`;
@@ -79,6 +90,11 @@ export class OrgAssetsService extends FileBrowserService {
     }
   }
 
+  /**
+   * Parses the organisation assets library item
+   * @param libItem Library item to parse
+   * @returns Organisation assets library
+   */
   private _parseOrgAssetsLibraryItem = (libItem: any): ILibrary => { // eslint-disable-line @typescript-eslint/no-explicit-any
     const orgAssetsLibrary: ILibrary = {
       absoluteUrl: this.buildAbsoluteUrl(libItem.LibraryUrl.DecodedUrl),

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -199,6 +199,7 @@ import { FieldPicker } from "../../../FieldPicker";
 import { IPersonaProps, Toggle } from "@fluentui/react";
 import { ListItemComments } from "../../../ListItemComments";
 import { ViewPicker } from "../../../controls/viewPicker";
+import { GeneralHelper } from "../../../Utilities";
 
 
 
@@ -736,13 +737,15 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
   }
 
   private _onFilePickerSave = async (filePickerResult: IFilePickerResult[]) => {
-    this.setState({ filePickerResult: filePickerResult });
     if (filePickerResult && filePickerResult.length > 0) {
       for (var i = 0; i < filePickerResult.length; i++) {
         const item = filePickerResult[i];
         const fileResultContent = await item.downloadFileContent();
         console.log(fileResultContent);
+        filePickerResult[i].fileSize = fileResultContent.size;
       }
+
+      this.setState({ filePickerResult: filePickerResult });
     }
   }
 
@@ -1854,7 +1857,7 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
                   FileName: {this.state.filePickerResult[0].fileName}
                 </div>
                 <div>
-                  File size: {this.state.filePickerResult[0].fileSize}
+                  File size: {GeneralHelper.formatBytes(this.state.filePickerResult[0].fileSize, 2)}
                 </div>
               </div>
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1766

#### What's in this Pull Request?

* Issue fix when browsing to the organization assets library from a root site.
* Typo / methods order fix
* Method documentation
* File size display fix in the ControlsTest webpart
