### PR TITLE
DynamicForm storeLastActiveTab option

### DIFF
--- a/docs/documentation/docs/controls/DynamicForm.md
+++ b/docs/documentation/docs/controls/DynamicForm.md
@@ -65,6 +65,7 @@ The `DynamicForm` can be configured with the following properties:
 | saveDisabled | boolean | no | Specifies if save button is disabled. |
 | validationErrorDialogProps | IValidationErrorDialogProps | no | Specifies validation error dialog properties |
 | customIcons | { [ columnInternalName: string ]: string } | no | Specifies custom icons for the form. The key of this dictionary is the column internal name, the value is the Fluent UI icon name. | 
+| storeLastActiveTab | boolean | no |  When uploading files: Specifies if last active tab will be stored after the Upload panel has been closed. Note: the value of selected tab is stored in the queryString hash. Default - `true` |
 
 ## Validation Error Dialog Properties `IValidationErrorDialogProps`
 | Property | Type | Required | Description |

--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -1439,6 +1439,7 @@ export class DynamicForm extends React.Component<
         hideLinkUploadTab={true}
         hideSiteFilesTab={true}
         checkIfFileExists={true}
+        storeLastActiveTab={this.props.storeLastActiveTab ?? true}
       />
       {selectedFile && <div className={styles.selectedFileContainer}>
         <Icon iconName={this.getFileIconFromExtension()} />

--- a/src/controls/dynamicForm/IDynamicFormProps.ts
+++ b/src/controls/dynamicForm/IDynamicFormProps.ts
@@ -133,4 +133,10 @@ export interface IDynamicFormProps {
    */
   fieldOrder?: string[]
 
+  /**
+   * When uploading files: Specifies if last active tab will be stored after the Upload panel has been closed.
+   * Note: the value of selected tab is stored in the queryString hash.
+   * @default true
+   */
+   storeLastActiveTab?: boolean;
 }


### PR DESCRIPTION
New option to set the storeLastActiveTab property of the FilePicker within the DynamicForm.

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

New option to set the storeLastActiveTab property of the FilePicker within the DynamicForm. Useful if you use the hashes within your solution and don't want them to be deleted as soon as a file gets picked.