### PR TITLE
Fix #1874: ListItemComments - can't select text from comment

### DIFF
--- a/src/controls/listItemComments/components/Comments/useListItemCommentsStyles.ts
+++ b/src/controls/listItemComments/components/Comments/useListItemCommentsStyles.ts
@@ -52,6 +52,7 @@ export const useListItemCommentsStyles = (): returnObjectStyles => {
       marginBottom: 7,
       width: 322,
       backgroundColor: theme.neutralLighterAlt,
+      userSelect: "text",
       ":hover": {
         borderColor: theme.themePrimary,
         borderWidth: 1,
@@ -64,6 +65,7 @@ export const useListItemCommentsStyles = (): returnObjectStyles => {
       marginBottom: 7,
       width: 322,
       backgroundColor: theme.themeLighter,
+      userSelect: "text",
       border: "solid 3px "+theme.themePrimary,
       ":hover": {
         borderColor: theme.themePrimary,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1874

#### What's in this Pull Request?
Currently, ListItemComments uses Document Card as its container, which has `user-select` set to `none`. In comparison, SharePoint’s OOTB comments allow users to select and copy text. It would enhance usability to enable text selection here as well.
