### PR TITLE
Adds ability to create files/folders in subfolder using DynamicForm. Closes #1901

### DIFF
--- a/docs/documentation/docs/controls/DynamicForm.md
+++ b/docs/documentation/docs/controls/DynamicForm.md
@@ -66,6 +66,7 @@ The `DynamicForm` can be configured with the following properties:
 | validationErrorDialogProps | IValidationErrorDialogProps | no | Specifies validation error dialog properties |
 | customIcons | { [ columnInternalName: string ]: string } | no | Specifies custom icons for the form. The key of this dictionary is the column internal name, the value is the Fluent UI icon name. | 
 | storeLastActiveTab | boolean | no |  When uploading files: Specifies if last active tab will be stored after the Upload panel has been closed. Note: the value of selected tab is stored in the queryString hash. Default - `true` |
+| folderPath | string | no | Server relative or library relative folder to create the item in. This option is only available for document libraries and works only when the contentTypeId is specified and has a base type of type Document or Folder. Defaults to the root folder of the library. |
 
 ## Validation Error Dialog Properties `IValidationErrorDialogProps`
 | Property | Type | Required | Description |

--- a/src/controls/dynamicForm/IDynamicFormProps.ts
+++ b/src/controls/dynamicForm/IDynamicFormProps.ts
@@ -139,4 +139,11 @@ export interface IDynamicFormProps {
    * @default true
    */
    storeLastActiveTab?: boolean;
+
+  /**
+   * Library relative folder to create the item in. 
+   * This option is only available for document libraries and works only when the contentTypeId is specified and has a base type of type Document or Folder. 
+   * Defaults to the root folder.
+   */
+  folderPath?: string;
 }


### PR DESCRIPTION
Closes #1901

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | Closes #1901

#### What's in this Pull Request?

In its current state, a dynamic form always creates new items/files/folders in the root folder of a list or library. This is not very handy when using the dynamic form on document libraries. For example as a custom form to create document sets.

This PR adds the ability to create files, folders and document sets in subfolders. 

I've added an extra option to do this. So the user has full control over the folder that should be used. In this way it doesn't matter how the form is rendered. A `RootFolder` querystring parameter may be available that the user can use. (For example in the NewForm of an SPFx FormCustomizer) Or it may not be available. The user is in control of what value he supplies...

> The feature does not work for list items. Even if list items can also be created in folders. I've not added that currently as it was a little bit more work that I'm not sure is very relevant.

#### Testing instructions

To test this feature, you'll need a library where you can create document sets. In `TestForm.tsx` fill in the `contentTypeId`, `folderPath` AND `hiddenFields` properties as follows:

```tsx
<DynamicForm
          context={this.props.context}
          contentTypeId='0x0120D52000796BC7FCC8B819488729FB2B77B0E799002B2379630DCCB04D883603B763E843D7'
          listId={this.props.context.list.guid.toString()}
          listItemId={this.props.context.itemId}
          hiddenFields={['FileLeafRef']}
          folderPath='Some subfolder/Some deeper subfolder'
          onListItemLoaded={async (listItemData: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
            console.log(listItemData);
          }} />
```

For the `folderPath` option, you can also use a server relative URL. For example when using the RootFolder querystring of an SPFx form customizer. However: it should be a path to the same library, otherwise the code will fail.

`FileLeafRef` should be excluded in `hiddenFields`, otherwise the form will not submit. This is supposed to be fixed in #1906.