### PR TITLE
Adds ability to render file/folder name field in DynamicForm and Field. Closes #1683

### DIFF
--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -548,6 +548,25 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
           {descriptionEl}
           {errorTextEl}
         </div>;
+
+      case 'File':
+        return <div className={styles.fieldContainer}>
+          <div className={styles.titleContainer}>
+            <Icon className={styles.fieldIcon} iconName={customIcon ?? "Page"} />
+            {labelEl}
+          </div>
+          <TextField
+            defaultValue={defaultValue}
+            value={valueToDisplay}
+            placeholder={placeholder}
+            className={styles.fieldDisplay}
+            onChange={(e, newText) => { this.onChange(newText); }}
+            disabled={disabled}
+            onBlur={this.onBlur}
+            errorMessage={errorText}
+          />
+          {descriptionEl}
+        </div>;
     }
 
     return null;

--- a/src/services/ISPService.ts
+++ b/src/services/ISPService.ts
@@ -59,8 +59,8 @@ export enum IMEMode {
   Active  = 2, 
   Disabled = 3
 }
-export type ClientFormFieldInfoFieldType = "Attachments" | "Text" | "Number" | "Boolean" | "Choice" | "MultiChoice" | "User" | "UserMulti" | "Note" | "DateTime" | "URL" | "Lookup" | "LookupMulti" | "Hyperlink" | "Thumbnail" | "Currency" | "Location" | "TaxonomyFieldType" | "TaxonomyFieldTypeMulti";
-export type ClientFormFieldInfoType = "Attachments" | "Text" | "Number" | "Boolean" | "Choice" | "User" | "Note" | "DateTime" | "URL" | "Lookup" | "URL" | "Thumbnail" | "Currency" | "Location";
+export type ClientFormFieldInfoFieldType = "Attachments" | "Text" | "Number" | "Boolean" | "Choice" | "MultiChoice" | "User" | "UserMulti" | "Note" | "DateTime" | "URL" | "Lookup" | "LookupMulti" | "Hyperlink" | "Thumbnail" | "Currency" | "Location" | "TaxonomyFieldType" | "TaxonomyFieldTypeMulti" | "File";
+export type ClientFormFieldInfoType = "Attachments" | "Text" | "Number" | "Boolean" | "Choice" | "User" | "Note" | "DateTime" | "URL" | "Lookup" | "URL" | "Thumbnail" | "Currency" | "Location" | "File";
 export interface IClientFormBaseInfo {
   Id: string;
   Title: string;
@@ -98,6 +98,10 @@ export interface IClientFormLocationFieldInfo extends IClientFormBaseInfo {
 export interface IClientFormBooleanFieldInfo extends IClientFormBaseInfo {
   FieldType: "Boolean";
   Type: "Boolean";
+}
+export interface IClientFormFileFieldInfo extends IClientFormBaseInfo {
+  FieldType: "File";
+  Type: "File";
 }
 export interface IClientFormTextFieldInfo extends IClientFormBaseInfo {
   FieldType: "Text" | "Note";
@@ -213,7 +217,7 @@ export interface IClientFormLookupFieldInfo extends IClientFormBaseLookupFieldIn
   LookupListUrl: string;
   LookupFieldName: string;
 }
-export type ClientFormFieldInfo = IClientFormTextFieldInfo | IClientFormNumberFieldInfo | IClientFormChoiceFieldInfo | IClientFormDateFieldInfo | IClientFormLookupFieldInfo | IClientFormUserFieldInfo | IClientFormTaxonomyFieldInfo | IClientFormImageFieldInfo | IClientFormHyperlinkFieldInfo | IClientFormLocationFieldInfo | IClientFormCurrencyFieldInfo | IClientFormBooleanFieldInfo;
+export type ClientFormFieldInfo = IClientFormTextFieldInfo | IClientFormNumberFieldInfo | IClientFormChoiceFieldInfo | IClientFormDateFieldInfo | IClientFormLookupFieldInfo | IClientFormUserFieldInfo | IClientFormTaxonomyFieldInfo | IClientFormImageFieldInfo | IClientFormHyperlinkFieldInfo | IClientFormLocationFieldInfo | IClientFormCurrencyFieldInfo | IClientFormBooleanFieldInfo | IClientFormFileFieldInfo;
 export interface IClientFormInfoByContentType {
   [contentType: string]: ClientFormFieldInfo[];
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1683

#### What's in this Pull Request?

This PR contains the code necessary to render the `FileLeafRef` field when using a `DynamicForm` or `DynamicField`. 

I tested this using a Document Set Form:

```tsx
<DynamicForm
  context={this.props.context}
  contentTypeId='0x0120D52000796BC7FCC8B819488729FB2B77B0E799002B2379630DCCB04D883603B763E843D7'
  listId={this.props.context.list.guid.toString()}
  listItemId={this.props.context.itemId}
  onListItemLoaded={async (listItemData: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
    console.log(listItemData);
  }} />
```
> Important: I was not able to test the DynamicForm on a File, I didn't get it to work without a generic SharePoint error when loading SPListForm.aspx. Maybe you guys have a way to test that scenario....?


#### Note on loading the list item

The FileLeafRef field is not loaded by default when calling the SharePoint REST API, so I included an extra select statement: `.select("*", "FileLeafRef")`. 

