### PR TITLE
Fix #1877: WebPartTitle Control Fails to Update After Initial Save

### DIFF
--- a/src/controls/webPartTitle/WebPartTitle.tsx
+++ b/src/controls/webPartTitle/WebPartTitle.tsx
@@ -54,7 +54,7 @@ export class WebPartTitle extends React.Component<IWebPartTitleProps, {}> {
           <div className={styles.webPartTitle} style={{ color: color }}>
             {
               this.props.displayMode === DisplayMode.Edit && (
-                <textarea placeholder={this.props.placeholder ? this.props.placeholder : strings.WebPartTitlePlaceholder} aria-label={strings.WebPartTitleLabel} onChange={this._onChange} value={this.props.title} />
+                <textarea placeholder={this.props.placeholder ? this.props.placeholder : strings.WebPartTitlePlaceholder} aria-label={strings.WebPartTitleLabel} onChange={this._onChange} defaultValue={this.props.title} />
               )
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1877

#### What's in this Pull Request?

This PR fixes the issue described in #1877. The `WebPartTitle` component switched to use `value` in stead of the `defaultValue` property on the `textarea`. This causes the value to not being updated.
