### PR TITLE
Updated visibility of controls in the ControlsTest web part

### DIFF
--- a/src/webparts/controlsTest/IControlsTestWebPartProps.ts
+++ b/src/webparts/controlsTest/IControlsTestWebPartProps.ts
@@ -1,12 +1,12 @@
-export type ValidControls = "all" | 
-  "accessibleAccordion" | "adaptiveCardDesignerHost" | "adaptiveCardHost" | 
-  "animatedDialog" | "Carousel" | "ChartControl" | 
-  "ComboBoxListItemPicker" | "Dashboard" | "DateTimePicker" | 
-  "DragDropFiles" | "DynamicForm" | "EnhancedThemeProvider" | 
-  "FieldCollectionData" | "FieldPicker" | "FilePicker" | 
+export type ValidControls = "all" |
+  "accessibleAccordion" | "adaptiveCardDesignerHost" | "adaptiveCardHost" |
+  "animatedDialog" | "Carousel" | "ChartControl" |
+  "ComboBoxListItemPicker" | "Dashboard" | "DateTimePicker" |
+  "DragDropFiles" | "DynamicForm" | "EnhancedThemeProvider" |
+  "FieldCollectionData" | "FieldPicker" | "FilePicker" |
   "FileTypeIcon" | "FolderExplorer" | "FolderPicker" |
   "GridLayout" | "IconPicker" | "IFrameDialog" |
-  "IFramePanel" | "ListPicker" | "ListItemPicker" |
+  "IFramePanel" | "ListPicker" | "ListItemAttachments" | "ListItemPicker" |
   "ListItemComments" | "ViewPicker" | "ListView" |
   "LocationPicker" | "Map" | "ModernAudio" |
   "ModernTaxonomyPicker" | "Pagination" | "PeoplePicker" |

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -988,6 +988,8 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           <div className={`${styles.row} ${styles.controlFiltersContainer}`}>
             <PrimaryButton text="Open Web Part Settings" iconProps={{ iconName: 'Settings' }} onClick={this.props.onOpenPropertyPane} />
           </div>
+        </div>
+        <div id="ListItemAttachmentsDiv" className={styles.container} hidden={!controlVisibility.ListItemAttachments}>
           <ListItemAttachments listId='e7a3ef63-70f6-4cc1-b95c-1f9eb8af2c8c' context={this.props.context} />
         </div>
         <div id="WebPartTitleDiv" className={styles.container} hidden={!controlVisibility.WebPartTitle}>

--- a/src/webparts/controlsTest/propertyPane/controls/ControlToggles.tsx
+++ b/src/webparts/controlsTest/propertyPane/controls/ControlToggles.tsx
@@ -32,13 +32,13 @@ export class ControlToggles extends React.Component<IControlTogglesProps, IContr
                         return null;
                     }
                     return (
-                        <Toggle 
-                            key={control} 
-                            label={this.getProperCase(control)} 
+                        <Toggle
+                            key={control}
+                            label={this.getProperCase(control)}
                             checked={this.props.controlVisibility && this.props.controlVisibility[control] || false}
                             onChange={(e, checked) => {
                                 this.props.onChange(control, checked);
-                            }} 
+                            }}
                         />
                     );
                 }) }
@@ -48,15 +48,15 @@ export class ControlToggles extends React.Component<IControlTogglesProps, IContr
 
     private getValidControls(): string[] {
         const validControls: ValidControls[] = [
-            "all", 
-            "accessibleAccordion", "adaptiveCardDesignerHost", "adaptiveCardHost", 
-            "animatedDialog", "Carousel", "ChartControl", 
-            "ComboBoxListItemPicker", "Dashboard", "DateTimePicker", 
-            "DragDropFiles", "DynamicForm", "EnhancedThemeProvider", 
-            "FieldCollectionData", "FieldPicker", "FilePicker", 
+            "all",
+            "accessibleAccordion", "adaptiveCardDesignerHost", "adaptiveCardHost",
+            "animatedDialog", "Carousel", "ChartControl",
+            "ComboBoxListItemPicker", "Dashboard", "DateTimePicker",
+            "DragDropFiles", "DynamicForm", "EnhancedThemeProvider",
+            "FieldCollectionData", "FieldPicker", "FilePicker",
             "FileTypeIcon", "FolderExplorer", "FolderPicker",
             "GridLayout", "IconPicker", "IFrameDialog",
-            "IFramePanel", "ListPicker", "ListItemPicker",
+            "IFramePanel", "ListPicker", "ListItemAttachments","ListItemPicker",
             "ListItemComments", "ViewPicker", "ListView",
             "LocationPicker", "Map", "ModernAudio",
             "ModernTaxonomyPicker", "Pagination", "PeoplePicker",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]

#### What's in this Pull Request?

This pull request is to fix the display of the ListItemAttachments control in the ControlsTest web part.
The web part was always showing the ListItemAttachments control, now it can be displayed or hide as all the other controls.
