### PR TITLE
🐛 - Fix 1655- Dynamic form should not display any validation errors until the user clicks Save/Submit, or leaves the focus of a required control - (Repo Rescuer Challenge)

### DIFF
--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -32,8 +32,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       spfxContext: { pageContext: this.props.context.pageContext }
     });
     this.state = {
-      changedValue: props.defaultValue !== undefined || props.defaultValue !== '' || props.defaultValue !== null || !this.isEmptyArray(props.defaultValue) ? props.defaultValue : null,
-      listItemId: props.listItemId
+      changedValue: props.defaultValue !== undefined || props.defaultValue !== '' || props.defaultValue !== null || !this.isEmptyArray(props.defaultValue) ? props.defaultValue : null
     };
   }
 
@@ -643,12 +642,11 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
 
   private getRequiredErrorText = (): string => {
     const {
-      changedValue,
-      listItemId
+      changedValue
     } = this.state;
-    const { value, newValue, required } = this.props;
+    const { value, newValue, required,listItemId } = this.props;
 
-    if (listItemId !== undefined && listItemId !== '' && listItemId !== null) {
+    if (listItemId !== undefined && listItemId !== null) {
       if (newValue === undefined) {
         return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue))
         && (value === undefined || value === '' || value === null || this.isEmptyArray(value)) ? strings.DynamicFormRequiredErrorMessage : null;
@@ -662,8 +660,7 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
 
   private getNumberErrorText = (): string => {
     const {
-      changedValue,
-      listItemId
+      changedValue
     } = this.state;
     const {
       cultureName,
@@ -673,14 +670,15 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       showAsPercentage,
       value,
       newValue,
-      required
+      required,
+      listItemId
     } = this.props;
 
     if (required && newValue!==undefined && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) ) {
       return strings.DynamicFormRequiredErrorMessage;
     }
 
-    if(listItemId !== undefined && listItemId !== '' && listItemId !== null){
+    if(listItemId !== undefined && listItemId !== null){
       if (required && newValue===undefined &&  (value === undefined || value === '' || value === null || this.isEmptyArray(value)) && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) ) {
         return strings.DynamicFormRequiredErrorMessage;
       }

--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -32,7 +32,8 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       spfxContext: { pageContext: this.props.context.pageContext }
     });
     this.state = {
-      changedValue: props.defaultValue !== undefined || props.defaultValue !== '' || props.defaultValue !== null || !this.isEmptyArray(props.defaultValue) ? props.defaultValue : null
+      changedValue: props.defaultValue !== undefined || props.defaultValue !== '' || props.defaultValue !== null || !this.isEmptyArray(props.defaultValue) ? props.defaultValue : null,
+      listItemId: props.listItemId
     };
   }
 
@@ -642,22 +643,27 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
 
   private getRequiredErrorText = (): string => {
     const {
-      changedValue
+      changedValue,
+      listItemId
     } = this.state;
-    const {value,newValue,required}=this.props;
-    if(newValue===undefined){
-      return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) 
-      && (value === undefined || value === '' || value === null || this.isEmptyArray(value))? strings.DynamicFormRequiredErrorMessage : null;
+    const { value, newValue, required } = this.props;
+
+    if (listItemId !== undefined && listItemId !== '' && listItemId !== null) {
+      if (newValue === undefined) {
+        return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue))
+        && (value === undefined || value === '' || value === null || this.isEmptyArray(value)) ? strings.DynamicFormRequiredErrorMessage : null;
+      } else {
+        return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) ? strings.DynamicFormRequiredErrorMessage : null;
+      }
     }
-    else{
-      return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) ? strings.DynamicFormRequiredErrorMessage : null;
-    }
-   
+
+    return null;
   }
 
   private getNumberErrorText = (): string => {
     const {
-      changedValue
+      changedValue,
+      listItemId
     } = this.state;
     const {
       cultureName,
@@ -674,9 +680,12 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
       return strings.DynamicFormRequiredErrorMessage;
     }
 
-    if (required && newValue===undefined &&  (value === undefined || value === '' || value === null || this.isEmptyArray(value)) && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) ) {
-      return strings.DynamicFormRequiredErrorMessage;
+    if(listItemId !== undefined && listItemId !== '' && listItemId !== null){
+      if (required && newValue===undefined &&  (value === undefined || value === '' || value === null || this.isEmptyArray(value)) && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) ) {
+        return strings.DynamicFormRequiredErrorMessage;
+      }
     }
+
 
     let minValue = minimumValue !== undefined && minimumValue !== -(Number.MAX_VALUE) ? minimumValue : undefined;
     let maxValue = maximumValue !== undefined && maximumValue !== Number.MAX_VALUE ? maximumValue : undefined;

--- a/src/controls/dynamicForm/dynamicField/IDynamicFieldState.ts
+++ b/src/controls/dynamicForm/dynamicField/IDynamicFieldState.ts
@@ -3,4 +3,5 @@ export interface IDynamicFieldState {
   * The options available to the listPicker
   */
   changedValue: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  listItemId:any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/src/controls/dynamicForm/dynamicField/IDynamicFieldState.ts
+++ b/src/controls/dynamicForm/dynamicField/IDynamicFieldState.ts
@@ -3,5 +3,4 @@ export interface IDynamicFieldState {
   * The options available to the listPicker
   */
   changedValue: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  listItemId:any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1655 

#### What's in this Pull Request?
Fixing issue #1655 

#### Observation
When loading a Dynamic Form with no list item id (new item), the form should not display any validation errors until the user clicks Save/Submit, or leaves the focus of a required control.

#### Actual behavior
When loading a Dynamic Form with no list item id (new item) all of the required fields display validation errors by default.

#### Solution
In ```DynamicField.tsx``` component, individual field is set and the validation is done through the methods ```getRequiredErrorText()``` and ```getNumberErrorText()```

These methods currently are only checking with ```changedValue``` property, which will be always empty for a new item. An additional check is done on basis of ```listItemId``` assuming that the fact that for new item, this will be empty, we can achieve to not to show the validation errors on the form. 

### Screenshots

#### Observed 

![Issue1655](https://github.com/user-attachments/assets/0d7ca34b-7fe0-4d6a-aee8-f9b910f4403e)

#### After change

![Issue1615](https://github.com/user-attachments/assets/b73dc501-41a2-4179-b605-234d7cbd2c6a)


#### Edit scenario

![Issue1655-Edit](https://github.com/user-attachments/assets/d1542e62-943a-4f43-af8a-d56022c96d1c)


Thanks,
Nish
