### PR TITLE
🐛 - Fixes-Issue 1953 - DynamicForm required User Fields not checked before submit (Repo Rescuer Challenge)

### DIFF
--- a/src/controls/dynamicForm/dynamicField/DynamicField.tsx
+++ b/src/controls/dynamicForm/dynamicField/DynamicField.tsx
@@ -646,13 +646,13 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
     } = this.state;
     const {value,newValue,required}=this.props;
     if(newValue===undefined){
-      return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) 
-      && (value === undefined || value === '' || value === null || this.isEmptyArray(value))? strings.DynamicFormRequiredErrorMessage : null;
+      return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue))
+      && (value === undefined || value === '' || value === null || this.isEmptyArray(value) || this.checkUserArrayIsEmpty(value))? strings.DynamicFormRequiredErrorMessage : null;
     }
     else{
-      return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue)) ? strings.DynamicFormRequiredErrorMessage : null;
+      return required && (changedValue === undefined || changedValue === '' || changedValue === null || this.isEmptyArray(changedValue) || this.checkUserArrayIsEmpty(changedValue)) ? strings.DynamicFormRequiredErrorMessage : null;
     }
-   
+
   }
 
   private getNumberErrorText = (): string => {
@@ -715,6 +715,10 @@ export class DynamicField extends React.Component<IDynamicFieldProps, IDynamicFi
 
   private isEmptyArray(value): boolean {
     return Array.isArray(value) && value.length === 0;
+  }
+
+  private checkUserArrayIsEmpty = (value): boolean => {
+    return Array.isArray(value) && value.every(item => item === "");
   }
 
   private MultiChoice_selection = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void => {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1953

#### What's in this Pull Request?
Fix for Issue 1953

#### Observation
Required field validation is not working for User field (both single and multi select) as in below screens

![Issue+1953](https://github.com/user-attachments/assets/52927053-0366-40fd-836a-d232e20f5286)

![Issue+1953-1](https://github.com/user-attachments/assets/2b6fa2b4-e410-410b-9e32-6b22be41767e)

#### Actual behavior
Required field validation should work for all the fields. 

#### Solution

Upon further investigation, I discovered that the `value` for an empty user field is `['']`, and the validation fails when attempting to verify `isEmptyArray` because the value.length is 1. The following method consistently fails

```
  private isEmptyArray(value): boolean {
    return Array.isArray(value) && value.length === 0;
  }
```

 Including an additional userFields check as shown below 

```
  private checkUserArrayIsEmpty = (value): boolean => {
    return Array.isArray(value) && value.every(item => item === "");
  }
```

 which, in fact, verifies that each string in the array is empty, resuming the validation. 

#### Verification

![Issue+1953-2](https://github.com/user-attachments/assets/be6b0009-e727-4360-805e-73bb66f0db08)


Thanks,
Nish
