### PR TITLE
Fix default value for Date.Input in AdaptiveCardHost

### DIFF
--- a/src/controls/adaptiveCardHost/fluentUI/Elements.tsx
+++ b/src/controls/adaptiveCardHost/fluentUI/Elements.tsx
@@ -286,6 +286,7 @@ export class FluentUIDateInput extends Input {
             this.valueChanged();
           }}
           theme={theme}
+          value={this.defaultValue ? this.convertStringToDate(this.defaultValue) : undefined}
           componentRef={(input) => { this.refControl = input; }}
         />
       </ThemeProvider>;
@@ -360,6 +361,12 @@ export class FluentUIDateInput extends Input {
     if (this._value) {
       const offset = this._value.getTimezoneOffset();
       const value = new Date(this._value.getTime() - (offset * 60 * 1000));
+      return value.toISOString().split('T')[0];
+    }
+    else if (this.defaultValue) {
+      const date = this.convertStringToDate(this.defaultValue);
+      const offset = date.getTimezoneOffset();
+      const value = new Date(date.getTime() - (offset * 60 * 1000));
       return value.toISOString().split('T')[0];
     }
     else {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1971

#### What's in this Pull Request?

Uses the default value for the Date.Input in the card payload to set the value for the FluentUI date control in the ```AdaptiveCardHost```control. Also returns the default value in the submitted adaptive card response if date not changed.
