### PR TITLE
Fix-1994 : Files keep loading when previewing all files in OneDrive

### DIFF
--- a/src/services/OneDriveService.ts
+++ b/src/services/OneDriveService.ts
@@ -115,11 +115,11 @@ export class OneDriveService extends FileBrowserService {
       if (!oneDriveLibsData || !oneDriveLibsData.value || oneDriveLibsData.value.length === 0) {
         throw new Error(`Cannot read one drive libs data.`);
       }
-
+      const isDefaultLang = this.isCurrentLanguageDefault();
       const myDocumentsLibrary = oneDriveLibsData.value[0];
-      this.oneDrivePersonalLibraryTitle = myDocumentsLibrary.Title;
-      this.oneDriveRootFolderRelativeUrl = `${myDocumentsLibrary.ParentWebUrl}/${myDocumentsLibrary.Title}`;
-      this.oneDriveRootFolderAbsoluteUrl = `${this.oneDrivePersonalUrl}${myDocumentsLibrary.Title}`;
+      this.oneDrivePersonalLibraryTitle = isDefaultLang ? myDocumentsLibrary.Title : myDocumentsLibrary.EntityTypeName;
+      this.oneDriveRootFolderRelativeUrl = `${myDocumentsLibrary.ParentWebUrl}/${isDefaultLang ? myDocumentsLibrary.Title : myDocumentsLibrary.EntityTypeName}`;
+      this.oneDriveRootFolderAbsoluteUrl = `${this.oneDrivePersonalUrl}${isDefaultLang ? myDocumentsLibrary.Title : myDocumentsLibrary.EntityTypeName}`;
     } catch (error) {
       console.error(`[FileBrowserService.getOneDrivePersonalUrl] Err='${error.message}'`);
       this.oneDriveRootFolderAbsoluteUrl = null;
@@ -182,5 +182,12 @@ export class OneDriveService extends FileBrowserService {
    */
   protected buildAbsoluteUrl = (relativeUrl: string): string => {
     return `https://${this.oneDrivePersonalUrl.split("//")[1].split("/")[0]}${relativeUrl}`;
+  }
+
+  /**
+   * Checks if the current language is default (en-US)
+   */
+  public isCurrentLanguageDefault(): boolean {
+    return this.context.pageContext.cultureInfo.currentUICultureName === 'en-US';
   }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1994 

#### What's in this Pull Request?
Fix for the issue `Files keep loading when previewing all files in OneDrive` as mentioned in #1994 

#### Issue 
While using `FilePicker` control, When switching to the OneDrive tab in the FilePicker, it shows a loading spinner indefinitely and never displays the files. All other tabs in the FilePicker — such as Recent, Site, and Upload — work as expected and load properly.

#### Solution
(Root cause analysis was already done by the issue reporter)
The title of the documents library will vary if the system language is different other than `English`. For instance, The document library Title in `English` is as `Documents` where-in, in swedish it is `Dokument`. 

By checking the default language as below, 

```
  public isCurrentLanguageDefault(): boolean {
    return this.context.pageContext.cultureInfo.currentUICultureName === 'en-US';
  }
```

and having a conditional check as below, 

```
      const isDefaultLang = this.isCurrentLanguageDefault();
      const myDocumentsLibrary = oneDriveLibsData.value[0];
      this.oneDrivePersonalLibraryTitle = isDefaultLang ? myDocumentsLibrary.Title : myDocumentsLibrary.EntityTypeName;
      this.oneDriveRootFolderRelativeUrl = `${myDocumentsLibrary.ParentWebUrl}/${isDefaultLang ? myDocumentsLibrary.Title : myDocumentsLibrary.EntityTypeName}`;
      this.oneDriveRootFolderAbsoluteUrl = `${this.oneDrivePersonalUrl}${isDefaultLang ? myDocumentsLibrary.Title : myDocumentsLibrary.EntityTypeName}`;
```

Resolves the issue. 

Thanks,
Nish