### PR TITLE
Update FolderExplorerService.ts to add import @pnp/sp/files

### DIFF
--- a/src/services/FolderExplorerService.ts
+++ b/src/services/FolderExplorerService.ts
@@ -6,6 +6,7 @@ import { sp } from "@pnp/sp";
 import "@pnp/sp/webs";
 import { Web } from "@pnp/sp/webs";
 import "@pnp/sp/folders";
+import "@pnp/sp/files";
 import "@pnp/sp/lists";
 import { IFolderAddResult } from "@pnp/sp/folders";
 import { IFileInfo } from "@pnp/sp/files";


### PR DESCRIPTION
Without the import @pnp/sp/files the methid _getFiles will fail as  web.getFolderByServerRelativePath(folderRelativeUrl).files will be undefined and therfore the next .select will fail.

adding the import fixed the issue

| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
When using the FolderExplorer with the option showFiles, the folderxplorer doesnt show the files + it shows the following error

Cannot read properties of undefined (reading 'select')

When investigating i found out that the import of pnp/sp/files was missing, which caused that the result of web.getFolderByServerRelativePath didnt contain a property files

#### Guidance
- *You can delete this section when you are submitting the pull request.* 
- *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
- *Please target your PR to **dev** branch.*
