### PR TITLE
Fix special characters encoding in ListItemComments. Closes #2047

### DIFF
--- a/src/controls/listItemComments/hooks/useSpAPI.ts
+++ b/src/controls/listItemComments/hooks/useSpAPI.ts
@@ -5,6 +5,7 @@ import { IlistItemCommentsResults } from "./../models";
 import { IAddCommentPayload } from "../models/IAddCommentPayload";
 import { IComment } from "../components/Comments/IComment";
 import { PageContext } from "@microsoft/sp-page-context";
+import { GeneralHelper } from '../../../common/utilities/GeneralHelper';
 interface returnObject {
   getListItemComments: () => Promise<IlistItemCommentsResults>;
   getNextPageOfComments: (
@@ -53,9 +54,10 @@ export const useSpAPI = (): returnObject => {
         webUrl ?? _webUrl
       }/_api/web/lists(@a1)/GetItemById(@a2)/Comments()?@a1='${listId}'&@a2='${itemId}'`;
       const spOpts: ISPHttpClientOptions = {
-        body: `{ "text": "${comment.text}", "mentions": ${JSON.stringify(
-          comment.mentions
-        )}}`,
+        body: JSON.stringify({
+          text: GeneralHelper.encodeText(comment.text),
+          mentions: comment.mentions
+        }),
       };
       const _listResults: SPHttpClientResponse = await spHttpClient.post(
         `${_endPointUrl}`,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #2047

#### What's in this Pull Request?
- Fixed bug where comments with special characters (backslashes, quotes, newlines) failed to submit
- Replaced manual JSON string construction with proper `JSON.stringify()` and HTML entity encoding to match SharePoint's standard behavior

<img width="1498" height="367" alt="image" src="https://github.com/user-attachments/assets/c7577c77-98fc-4fd1-bdc9-c83abae8dafb" />



