### PR TITLE
Fix timezone issue in Calendar month view. Closes #2025

### DIFF
--- a/src/controls/calendar/Calendar.tsx
+++ b/src/controls/calendar/Calendar.tsx
@@ -7,7 +7,7 @@ import {
   webLightTheme,
 } from '@fluentui/react-components';
 import { ICalendarStyles, useCalendarStyles } from './hooks/useCalendarStyles';
-import { addDays, startOfMonth, startOfWeek } from 'date-fns';
+import { addDays, startOfMonth, startOfWeek, format } from 'date-fns';
 import { useEffect, useRef, useState } from 'react';
 
 import { Day } from './Day';
@@ -213,8 +213,9 @@ export const Calendar: React.FC<ICalendarControlProps> = ({
         currentDate.getFullYear(),
         currentDate.getMonth()
       );
-      const dayString = date.toISOString().split('T')[0];
-      return monthEvents[dayString]?.flatMap((slot) => slot) || [];
+      const dayString = format(date, 'yyyy-MM-dd');
+      const dayEvents = monthEvents[dayString]?.flatMap((slot) => slot) || [];
+      return dayEvents;
     },
     [currentDate, events]
   );


### PR DESCRIPTION
…ormat instead of toISOString

| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #2025 

#### What's in this Pull Request?
- Fixed timezone bug in Calendar month view where events weren't displaying for users in positive timezones (GMT+4, etc.)
- Replaced `toISOString().split('T')[0]` with `format(date, 'yyyy-MM-dd')` from date-fns for timezone-safe date string conversion

