### PR TITLE
Fix missing closing tag in CAML OrderBy query for calculated columns. Closes #1870

### DIFF
--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -237,7 +237,7 @@ export default class SPService implements ISPService {
         if (orderByParts[1] && orderByParts[1].toLowerCase() === 'desc') {
           ascStr = `Ascending="FALSE"`;
         }
-        orderByStr = `<OrderBy><FieldRef Name="${orderByParts[0]}" ${ascStr} />`;
+        orderByStr = `<OrderBy><FieldRef Name="${orderByParts[0]}" ${ascStr} /></OrderBy>`;
       }
 
       let filterPart = ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1870

#### What's in this Pull Request?
- Fixes missing closing `</OrderBy>` tag in CAML query for calculated columns in ListItemPicker
- Resolves 500 error when using calculated columns as `columnInternalName`

