### PR TITLE
Docs: Updated Folder explorer control documentation to correct a typo.

### DIFF
--- a/docs/documentation/docs/controls/FolderExplorer.md
+++ b/docs/documentation/docs/controls/FolderExplorer.md
@@ -1,6 +1,6 @@
 # FolderExplorer control
 
-This control allows you to explore a folder structure by clinking on a folder to load it's sub-folders and using a breadcrumb navigation to navigate back to a previous level.
+This control allows you to explore a folder structure by clicking on a folder to load it's sub-folders and using a breadcrumb navigation to navigate back to a previous level.
 It also allows the user to create a new folder at the current level being explored.
 
 Here is an example of the control:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | 

#### What's in this Pull Request?
Updated Folder explorer control documentation to correct a typo. The folder explorer control documentation has a wrong spelling as below. 

<img width="900" height="667" alt="image" src="https://github.com/user-attachments/assets/a9406050-a676-42bb-a52f-5916520f8b6e" />

Thanks,
Nish
