### PR TITLE
Issue 2074 - Pass through ImageProps to TreeItem's Icon

### DIFF
--- a/src/controls/treeView/TreeItem.tsx
+++ b/src/controls/treeView/TreeItem.tsx
@@ -198,7 +198,7 @@ export default class TreeItem extends React.Component<ITreeItemProps, ITreeItemS
             // Rendering when item has iconProps
             item.iconProps &&
             <span>
-              <Icon className={styles.icon} iconName={item.iconProps.iconName} style={item.iconProps.style} theme={this.props.theme} />
+              <Icon className={styles.icon} iconName={item.iconProps.iconName} style={item.iconProps.style} theme={this.props.theme} imageProps={item.iconProps.imageProps} />
               &nbsp;
             </span>
           }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | fixes #2074 

Resolves query in #2074 

#### What's in this Pull Request?

This simply passes through the `imageProps` prop of `IIconProps` to the `<Icon />` component that is rendered in a `<TreeItem />` when the `iconProps` prop is specified.



