### PR TITLE
Fix ReDoS vulnerability by upgrading markdown-it from 14.1.0 to 14.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "jotai": "^2.4.2",
         "lodash": "4.17.21",
         "maplibre-gl": "^5.6.1",
-        "markdown-it": "^14.1.0",
+        "markdown-it": "^14.1.1",
         "monaco-editor": "^0.29.1",
         "nano-css": "^5.3.4",
         "pmtiles": "^4.3.0",
@@ -33801,9 +33801,10 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jotai": "^2.4.2",
     "lodash": "4.17.21",
     "maplibre-gl": "^5.6.1",
-    "markdown-it": "^14.1.0",
+    "markdown-it": "^14.1.1",
     "monaco-editor": "^0.29.1",
     "nano-css": "^5.3.4",
     "pmtiles": "^4.3.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

This PR addresses a **Regular Expression Denial of Service (ReDoS)** vulnerability identified in markdown-it@14.1.0, which is currently referenced in the project dependencies.

