### PR TITLE
Upgrade lodash from 4.17.21 to 4.17.23 to address Prototype Pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "date-fns": "^2.22.1",
         "he": "^1.2.0",
         "jotai": "^2.4.2",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "maplibre-gl": "^5.6.1",
         "markdown-it": "^14.1.0",
         "monaco-editor": "^0.29.1",
@@ -7568,6 +7568,13 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@microsoft/sp-build-core-tasks/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -9213,6 +9220,13 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/@microsoft/spfx-heft-plugins/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@microsoft/spfx-heft-plugins/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -33319,9 +33333,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "date-fns": "^2.22.1",
     "he": "^1.2.0",
     "jotai": "^2.4.2",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "maplibre-gl": "^5.6.1",
     "markdown-it": "^14.1.0",
     "monaco-editor": "^0.29.1",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

This PR upgrades lodash from **4.17.21 to 4.17.23 to address a known Prototype Pollution vulnerability** reported in earlier versions.

