### PR TITLE
#1332 - fixed DateTimePicker "showClearDate" button disabled state

### DIFF
--- a/src/controls/dateTimePicker/DateTimePicker.tsx
+++ b/src/controls/dateTimePicker/DateTimePicker.tsx
@@ -368,7 +368,7 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
                 }}
               />
             </div>
-            {showClearDate === true && this.state.day !== null && <IconButton iconProps={{ iconName: showClearDateIcon }} onClick={() => this.clearDate()} />}
+            {showClearDate === true && this.state.day !== null && !disabled && <IconButton iconProps={{ iconName: showClearDateIcon }} onClick={() => this.clearDate()} />}
 
           </div>
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1332

#### What's in this Pull Request?
Clear date button is now hidden when the DateTimePicker is disabled, since clearing a date has no function in that state.


