### PR TITLE
#822: ListView: add isMultiline support to IViewField for multiline text columns

### DIFF
--- a/docs/documentation/docs/controls/ListView.md
+++ b/docs/documentation/docs/controls/ListView.md
@@ -198,6 +198,7 @@ The `IViewField` has the following implementation:
 | minWidth         | number   | no       | Specify the minimum width of the column.                                                    |
 | maxWidth         | number   | no       | Specify the maximum width of the column.                                                    |
 | isResizable      | boolean  | no       | Determines if the column can be resized.                                                    |
+| isMultiline      | boolean  | no       | Determines if the column should be rendered as multiline. Has no effect when a custom `render` function is provided.    |
 | render           | function | no       | Override how the field has to get rendered.                                                 |
 
 The `IGrouping` has the following implementation:

--- a/src/controls/listView/IListView.ts
+++ b/src/controls/listView/IListView.ts
@@ -153,6 +153,10 @@ export interface IViewField {
    */
   isResizable?: boolean;
   /**
+   * Determines if the column should be rendered as multiline.
+   */
+  isMultiline?: boolean;
+  /**
    * Override the render method of the field
    */
   render?: (item?: any, index?: number, column?: IColumn) => any; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -24,6 +24,9 @@ const classNames = mergeStyleSets({
   wrapper: {
     height: '50vh',
     position: 'relative'
+  },
+  multilineCell: {
+    whiteSpace: 'break-spaces'
   }
 });
 
@@ -387,6 +390,12 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
     if (field.linkPropertyName) {
       return (item: any, index?: number, column?: IColumn) => { // eslint-disable-line @typescript-eslint/no-explicit-any
         return <a href={item[field.linkPropertyName]}>{item[column.fieldName]}</a>;
+      };
+    }
+
+    if (field.isMultiline) {
+      return (item: any, index?: number, column?: IColumn) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+        return <span className={classNames.multilineCell}>{item[column.fieldName]}</span>;
       };
     }
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ X ]
| New sample?      | [ ]
| Related issues?  | fixes #822

New prop in IViewField - isMultiline. 
Added style: whiteSpace: 'break-spaces'. As it is in SP for multiline fields
If field is multiline and isMultiline = false
<img width="467" height="157" alt="image" src="https://github.com/user-attachments/assets/d21d18cc-f351-4ddf-87b4-c693ad90194e" />

If field is multiline and isMultiline = true
![listview-multiline](https://github.com/user-attachments/assets/beb3c9a0-79b1-49ef-9a28-afab7fffe612)

