### PR TITLE
Show nameless people in PeoplePicker component.

### DIFF
--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -138,8 +138,10 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
         if (userResult) {
           selectedPersons.push(userResult);
         }
-        else if (valueAndTitle.length === 2 && valueAndTitle[1]) { //user not found.. bind the title if exists
-          const inactiveUser: IPersonaProps = { text: valueAndTitle[1] };
+        else {
+          // User not found (e.g. left the organization) - show with whatever identifier is available so they can be removed
+          const displayName = (valueAndTitle.length === 2 && valueAndTitle[1]) ? valueAndTitle[1] : valueAndTitle[0];
+          const inactiveUser: IPersonaProps = { text: displayName };
           selectedPersons.push(inactiveUser);
         }
       }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | partially #1010

#### What's in this Pull Request?

Displays users not found by `this.peopleSearchService.searchPersonByEmailOrLogin` in the PeoplePicker component.
Shows the person's email and allows for removal of such person, previously stuck in the picker as some kind of ghost.


#### Guidance
- Add PeoplePicker component with `defaultSelectedUser` that is found by `searchPersonByEmailOrLogin` (make up some email address) and you should see the person in the picker.
