### PR TITLE
Add aria-pressed to RichText text formatting buttons

### DIFF
--- a/src/controls/richText/RichText.test.tsx
+++ b/src/controls/richText/RichText.test.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { mount, ReactWrapper } from 'enzyme';
+import { RichText } from './RichText';
+
+describe('<RichText />', () => {
+  let host: HTMLDivElement;
+  let richtext: ReactWrapper;
+
+  // The toolbar positions itself from its parent element on mount, so the
+  // component has to be attached to the document rather than mounted detached.
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    richtext.detach();
+    document.body.removeChild(host);
+  });
+
+  const toolbarButton = (format: string): Element =>
+    richtext
+      .find(`button[aria-describedby="${format}-richtextbutton"]`)
+      .getDOMNode();
+
+  it('exposes the pressed state of the text formatting buttons', (done) => {
+    richtext = mount(<RichText isEditMode={true} value="<p>text</p>" />, {
+      attachTo: host,
+    });
+
+    // The inactive state is covered here through the rendered public contract.
+    // Exercising the active state requires Quill selection APIs that are not
+    // available in this jsdom test environment and is verified manually.
+    ['bold', 'italic', 'underline'].forEach((format) => {
+      expect(
+        toolbarButton(format).getAttribute('aria-pressed'),
+        `${format} button`
+      ).to.equal('false');
+    });
+
+    done();
+  });
+
+  it('exposes the pressed state of the link button', (done) => {
+    richtext = mount(<RichText isEditMode={true} value="<p>text</p>" />, {
+      attachTo: host,
+    });
+
+    // The link button's checked value reflects whether the selection is inside
+    // an existing hyperlink (formats.link from quill.getFormat), so it carries
+    // the same pressed semantics as the text formatting buttons.
+    expect(
+      toolbarButton('link').getAttribute('aria-pressed'),
+      'link button'
+    ).to.equal('false');
+
+    done();
+  });
+});

--- a/src/controls/richText/RichText.tsx
+++ b/src/controls/richText/RichText.tsx
@@ -676,6 +676,7 @@ export class RichText extends React.Component<IRichTextProps, IRichTextState> {
                 <IconButton
                   iconProps={{ iconName: 'Bold' }}
                   aria-describedby="bold-richtextbutton"
+                  toggle
                   checked={this.state.formats.bold}
                   onClick={this.onChangeBold}
                 />
@@ -690,6 +691,7 @@ export class RichText extends React.Component<IRichTextProps, IRichTextState> {
                 <IconButton
                   iconProps={{ iconName: 'Italic' }}
                   aria-describedby="italic-richtextbutton"
+                  toggle
                   checked={this.state.formats.italic}
                   onClick={this.onChangeItalic}
                 />
@@ -704,6 +706,7 @@ export class RichText extends React.Component<IRichTextProps, IRichTextState> {
                 <IconButton
                   iconProps={{ iconName: 'Underline' }}
                   aria-describedby="underline-richtextbutton"
+                  toggle
                   checked={this.state.formats.underline}
                   onClick={this.onChangeUnderline}
                 />
@@ -753,6 +756,7 @@ export class RichText extends React.Component<IRichTextProps, IRichTextState> {
                 calloutProps={{ gapSpace: 0 }}
               >
                 <IconButton
+                  toggle
                   checked={this.state.formats?.link !== undefined}
                   onClick={this.showInsertLinkDialog}
                   aria-describedby="link-richtextbutton"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?     | [ ]
| Related issues? | fixes #1945

#### What's in this Pull Request?

The Bold, Italic, Underline, and Link buttons pass `checked` to Fluent UI's
`IconButton` without `toggle`. `aria-pressed` is only rendered when `toggle`
is set, so screen readers never announce whether a format is active. Since
`checked` reflects the active formatting state at the current selection,
adding `toggle` ensures that `aria-pressed` is exposed correctly for all four
buttons.

Added regression coverage for Bold, Italic, Underline, and Link, verifying that
each button exposes `aria-pressed="false"` in its inactive state.

The new tests fail without the fix. `npm run build` passes with no new warnings.