### PR TITLE
fix(dynamic-form): use SharePoint display format for date fields

### DIFF
--- a/src/controls/dynamicForm/DynamicForm.tsx
+++ b/src/controls/dynamicForm/DynamicForm.tsx
@@ -1467,7 +1467,7 @@ export class DynamicFormBase extends React.Component<
               defaultValue = new Date(defaultValue);
             }
 
-            dateFormat = field.DateFormat || "DateOnly";
+            dateFormat = field.DisplayFormat === 1 ? "DateTime" : "DateOnly";
             defaultDayOfWeek = (await this._spService.getRegionalWebSettings(this.webURL)).FirstDayOfWeek;
           }
 


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #2132

#### What's in this Pull Request?

Resolve DateTime fields from DisplayFormat because SharePoint returns DateFormat as null. Preserve DateOnly as the default for unknown display formats and add regression coverage.

