### PR TITLE
Fix: Old CDN icon / image url does not work

### DIFF
--- a/src/controls/fileTypeIcon/FileTypeIcon.test.tsx
+++ b/src/controls/fileTypeIcon/FileTypeIcon.test.tsx
@@ -6,7 +6,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import { FileTypeIcon } from './FileTypeIcon';
 import { IconType, ApplicationType, ImageSize } from './IFileTypeIcon';
 
-const ICON_CDN_URL = `https://modernb.akamai.odsp.cdn.office.net/files/fabric-cdn-prod_20210703.001/assets/item-types`;
+const ICON_CDN_URL = `https://res-1.cdn.office.net/files/fabric-cdn-prod_20251008.001/assets/item-types`;
 
 describe('<FileTypeIcon />', () => {
   let fileTypeIcon: ReactWrapper;

--- a/src/controls/fileTypeIcon/FileTypeIcon.tsx
+++ b/src/controls/fileTypeIcon/FileTypeIcon.tsx
@@ -7,7 +7,7 @@ import { ICON_GENERIC_20 } from '.';
 
 const ICON_GENERIC = 'Page';
 const ICON_DEFAULT_SIZE = 'icon16';
-const ICON_CDN_URL = `https://modernb.akamai.odsp.cdn.office.net/files/fabric-cdn-prod_20210703.001/assets/item-types`;
+const ICON_CDN_URL = `https://res-1.cdn.office.net/files/fabric-cdn-prod_20251008.001/assets/item-types`;
 
 /**
 * File type icon component

--- a/src/loc/cs-cz.ts
+++ b/src/loc/cs-cz.ts
@@ -260,7 +260,7 @@ define([], () => {
     FolderFrontPlate:
       "https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/foldericons/folder-large_frontplate_nopreview.svg",
     FolderIconUrl:
-      "https://modernb.akamai.odsp.cdn.office.net/files/fabric-cdn-prod_20210703.001/assets/item-types/20/folder.svg",
+      "https://res-1.cdn.office.net/files/fabric-cdn-prod_20251008.001/assets/item-types/20/folder.svg",
     FolderLabelTemplate:
       "{0}, Složka, Upraveno {1}, upravil {2}, {3} položek, Soukromé",
     FromLinkLinkLabel: "Z odkazu",

--- a/src/loc/en-us.ts
+++ b/src/loc/en-us.ts
@@ -251,7 +251,7 @@ define([], () => {
     FolderFrontPlate:
       "https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/foldericons/folder-large_frontplate_nopreview.svg",
     FolderIconUrl:
-      "https://modernb.akamai.odsp.cdn.office.net/files/fabric-cdn-prod_20210703.001/assets/item-types/20/folder.svg",
+      "https://res-1.cdn.office.net/files/fabric-cdn-prod_20251008.001/assets/item-types/20/folder.svg",
     FolderLabelTemplate: "{0}, Folder, Modified {1}, edited by {2}, {3} items, Private",
     FromLinkLinkLabel: "From a link",
     ImageAltText: ".{0} Image",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #1978, #2104 

#### What's in this Pull Request?

Fix: Old CDN icon / image url does not work.
Replaced 
https://modernb.akamai.odsp.cdn.office.net/files/fabric-cdn-prod_20210703.001/assets/item-types
with 
https://res-1.cdn.office.net/files/fabric-cdn-prod_20251008.001/assets/item-types